### PR TITLE
Fix import error: remove non-existent WebSearchPreviewToolParam

### DIFF
--- a/src/deep_research_client/providers/openai.py
+++ b/src/deep_research_client/providers/openai.py
@@ -1,10 +1,9 @@
 """OpenAI Deep Research provider."""
 
-from typing import List, Optional, Any, Dict, cast
+from typing import List, Optional, Any, Dict
 
 import httpx
 from openai import OpenAI
-from openai.types.responses import WebSearchPreviewToolParam
 
 from . import ResearchProvider
 from ..models import ResearchResult, ProviderConfig
@@ -74,7 +73,7 @@ class OpenAIProvider(ResearchProvider):
             response = client.responses.create(
                 model=self.model,
                 input=input_messages,
-                tools=[cast(WebSearchPreviewToolParam, web_search_tool)],
+                tools=[web_search_tool],
             )
 
             # Extract the final report


### PR DESCRIPTION
The type WebSearchPreviewToolParam does not exist in openai.types.responses. This was causing ImportError when trying to use the package:

  ImportError: cannot import name 'WebSearchPreviewToolParam' from 'openai.types.responses'

The OpenAI SDK accepts plain dicts for tools configuration, so the cast and type annotation were unnecessary. Removed:
- Import of WebSearchPreviewToolParam (line 7)
- cast() wrapper on line 77

The web_search_tool is already properly typed as Dict[str, Any] which is sufficient for the OpenAI SDK.

Fixes issue reported in ai-gene-review after 0.1.0 release.