### PR TITLE
Fix PyPI upload error: move browser extra to dependency-groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,12 +29,14 @@ dependencies = [
 cyberian = [
     "cyberian>=0.2.0",
 ]
+# NOTE: browser extra removed - linkml-browser is not on PyPI
+# Install manually: uv pip install "linkml-browser @ git+https://github.com/linkml/linkml-browser.git"
+
+[dependency-groups]
 browser = [
     "linkml-browser @ git+https://github.com/linkml/linkml-browser.git",
     "markdown>=3.5.0",
 ]
-
-[dependency-groups]
 dev = [
     "mypy>=1.17.1",
     "ruff>=0.4.8",


### PR DESCRIPTION
## Summary
- PyPI doesn't allow direct git references in package metadata
- `linkml-browser` is not published to PyPI, blocking releases with error:
  ```
  Can't have direct dependency: linkml-browser@git+https://github.com/linkml/linkml-browser.git
  ```
- Moved `browser` from `[project.optional-dependencies]` to `[dependency-groups]`

## Changes
- `dependency-groups` are only used locally by uv, not included in published package metadata
- Users can still install browser dependencies via: `uv sync --group browser`

## Test plan
- [x] `uv build` succeeds locally
- [ ] PyPI release should now succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)