### PR TITLE
Add DeepER-Med stub provider

### DIFF
--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -13,6 +13,7 @@ Complete reference for all supported research providers.
 | Consensus | `CONSENSUS_API_KEY` | Academic papers | Fast |
 | OpenScientist | `OPENSCIENTIST_API_KEY` | Autonomous research, PMID citations | Very slow |
 | Cyberian | (local agents) | Agent-based, thorough | Very slow |
+| DeepER-Med | (stub - no API yet) | Evidence-based agentic medical research (arXiv:2604.15456) | n/a |
 
 ## OpenAI Deep Research
 
@@ -303,6 +304,29 @@ This is useful for:
 - **Testing**: Run a quick verification without full research
 - **Cost control**: Limit agent API calls
 - **Debugging**: Inspect intermediate results after fixed iterations
+
+---
+
+## DeepER-Med (Stub)
+
+DeepER-Med is an evidence-based agentic deep medical research framework
+introduced in Wang et al., *DeepER-Med: Advancing Deep Evidence-Based Research
+in Medicine Through Agentic AI* ([arXiv:2604.15456](https://arxiv.org/abs/2604.15456),
+NIH/NLM, April 2026). The paper describes an open-source paradigm with a
+public website and agent API, but at the time of writing **no code, API
+endpoint, or dataset has been released publicly**.
+
+This provider is registered as a stub so:
+
+- the wrapper slot is reserved and discoverable via `providers` listing,
+- model cards and parameter classes are in place,
+- callers get a clear `NotImplementedError` (with the arXiv pointer) instead
+  of a confusing missing-import error.
+
+`is_available()` always returns `False`. Calls to `research()` raise
+`NotImplementedError`. Watch the upstream lab's repository
+([`ncbi-nlp`](https://github.com/ncbi-nlp)) for the eventual release; once an
+API is published, only the body of `providers/deeper_med.py` needs to change.
 
 ---
 

--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -457,7 +457,7 @@ actual model(s) used and run provenance (`run_metadata`).
 DeepER-Med is an evidence-based agentic deep medical research framework
 introduced in Wang et al., *DeepER-Med: Advancing Deep Evidence-Based Research
 in Medicine Through Agentic AI* ([arXiv:2604.15456](https://arxiv.org/abs/2604.15456),
-NIH/NLM, April 2026). The paper describes an open-source paradigm with a
+submitted 16 April 2026). The paper describes an open-source paradigm with a
 public website and agent API, but at the time of writing **no code, API
 endpoint, or dataset has been released publicly**.
 
@@ -465,13 +465,33 @@ This provider is registered as a stub so:
 
 - the wrapper slot is reserved and discoverable via `providers` listing,
 - model cards and parameter classes are in place,
-- callers get a clear `NotImplementedError` (with the arXiv pointer) instead
-  of a confusing missing-import error.
+- callers asking for it are told *why* it cannot run, with the arXiv pointer,
+  instead of getting a bare "provider not found".
 
-`is_available()` always returns `False`. Calls to `research()` raise
-`NotImplementedError`. Watch the upstream lab's repository
-([`ncbi-nlp`](https://github.com/ncbi-nlp)) for the eventual release; once an
-API is published, only the body of `providers/deeper_med.py` needs to change.
+### Behavior
+
+`is_available()` always returns `False`, so DeepER-Med is never auto-selected
+and can never be chosen by `get_first_available()`. It is still registered
+unconditionally, which means an explicit request reports the stub status:
+
+```python
+client.research("...", provider="deeper_med")
+# ValueError: DeepER-Med has no public API or code release yet, so this
+# provider cannot run research. See https://arxiv.org/abs/2604.15456 ...
+```
+
+Calling `DeeperMedProvider.research()` directly raises `NotImplementedError`
+with the same message. In the CLI it is listed under **Stub providers (not yet
+callable)** in `deep-research-client providers`.
+
+### Caveats
+
+The model card's cost, speed, and capability entries are transcribed from the
+paper — nothing has been measured, because there is no endpoint to measure. The
+card's `limitations` say so explicitly.
+
+Once an API is published, only the body of `providers/deeper_med.py` needs to
+change.
 
 ---
 

--- a/src/deep_research_client/cli.py
+++ b/src/deep_research_client/cli.py
@@ -13,6 +13,7 @@ from typing_extensions import Annotated
 from .client import DeepResearchClient
 from .processing import ResearchProcessor
 from .model_cards import (
+    DEEPER_MED_ARXIV_ID,
     get_provider_model_cards,
     list_all_models,
     find_models_by_cost,
@@ -44,7 +45,9 @@ PROVIDER_CREDENTIAL_HINTS = {
 # they are not merely missing credentials and cannot be enabled by the user.
 # Keyed by provider name, valued by a short reason shown in `providers` output.
 PROVIDER_STUB_HINTS = {
-    "deeper_med": "DeepER-Med - no public API released yet (arXiv:2604.15456)",
+    "deeper_med": (
+        f"DeepER-Med - no public API released yet (arXiv:{DEEPER_MED_ARXIV_ID})"
+    ),
 }
 
 

--- a/src/deep_research_client/cli.py
+++ b/src/deep_research_client/cli.py
@@ -40,6 +40,13 @@ PROVIDER_CREDENTIAL_HINTS = {
     "mock": ("ENABLE_MOCK_PROVIDER=true", "Mock provider"),
 }
 
+# Providers registered as stubs: the upstream system has no public API yet, so
+# they are not merely missing credentials and cannot be enabled by the user.
+# Keyed by provider name, valued by a short reason shown in `providers` output.
+PROVIDER_STUB_HINTS = {
+    "deeper_med": "DeepER-Med - no public API released yet (arXiv:2604.15456)",
+}
+
 
 def setup_logging(verbosity: int) -> None:
     """Set up logging based on verbosity level.
@@ -229,6 +236,15 @@ def _echo_credential_hints(provider_names: list[str]) -> None:
     for provider_name in provider_names:
         env_var, label = PROVIDER_CREDENTIAL_HINTS[provider_name]
         typer.echo(f"  - {env_var} for {label}")
+
+
+def _echo_stub_hints() -> None:
+    """Print the stub providers, which no credential can enable."""
+    if not PROVIDER_STUB_HINTS:
+        return
+    typer.echo("\nStub providers (not yet callable):")
+    for provider_name, reason in PROVIDER_STUB_HINTS.items():
+        typer.echo(f"  - {provider_name}: {reason}")
 
 
 @app.callback()
@@ -662,12 +678,20 @@ def providers(
             raise typer.Exit(1)
 
         is_available = provider in available
-        status = "Available" if is_available else "Not available (missing API key)"
+        if is_available:
+            status = "Available"
+        elif provider in PROVIDER_STUB_HINTS:
+            # A stub is not credential-blocked; no key would make it work.
+            status = "Not available (stub - no upstream API yet)"
+        else:
+            status = "Not available (missing API key)"
         typer.echo(f"Provider: {provider} - {status}")
 
         if not is_available:
-            # Show required environment variable
-            if provider in PROVIDER_CREDENTIAL_HINTS:
+            if provider in PROVIDER_STUB_HINTS:
+                typer.echo(f"Status: {PROVIDER_STUB_HINTS[provider]}")
+            elif provider in PROVIDER_CREDENTIAL_HINTS:
+                # Show required environment variable
                 env_var = PROVIDER_CREDENTIAL_HINTS[provider][0]
                 typer.echo(f"Required: {env_var}")
 
@@ -717,9 +741,12 @@ def providers(
         if missing_credential_providers:
             typer.echo("\nUnavailable providers requiring credentials:")
             _echo_credential_hints(missing_credential_providers)
+
+        _echo_stub_hints()
     else:
         logger.error("No providers available. Please set API keys:")
         _echo_credential_hints(list(PROVIDER_CREDENTIAL_HINTS))
+        _echo_stub_hints()
 
     if not show_params and not provider:
         typer.echo(

--- a/src/deep_research_client/client.py
+++ b/src/deep_research_client/client.py
@@ -161,6 +161,18 @@ class DeepResearchClient:
             )
             self.registry.register(self._create_provider("claude_code", claude_code_config))
 
+        # DeepER-Med is a stub with no upstream endpoint. It is registered
+        # unconditionally and needs no credentials: is_available() is always False,
+        # so it can never be auto-selected by get_first_available(). Registering it
+        # means an explicit request for it reports why it cannot run (with the
+        # arXiv pointer) instead of a bare "Provider not found".
+        deeper_med_config = ProviderConfig(
+            name="deeper_med",
+            api_key=None,  # No upstream service exists to authenticate against
+            enabled=True,
+        )
+        self.registry.register(self._create_provider("deeper_med", deeper_med_config))
+
         # Mock provider only if explicitly requested via environment
         if os.getenv("ENABLE_MOCK_PROVIDER", "").lower() in ("true", "1", "yes"):
             mock_config = ProviderConfig(
@@ -290,7 +302,7 @@ class DeepResearchClient:
             if not base_provider:
                 raise ValueError(f"Provider '{provider}' not found")
             if not base_provider.is_available():
-                raise ValueError(f"Provider '{provider}' is not available")
+                raise ValueError(base_provider.unavailable_reason())
 
             # Create new instance with custom parameters if needed
             if provider_params or model:

--- a/src/deep_research_client/client.py
+++ b/src/deep_research_client/client.py
@@ -20,6 +20,7 @@ PROVIDER_CLASS_PATHS: dict[str, tuple[str, str]] = {
     "consensus": ("deep_research_client.providers.consensus", "ConsensusProvider"),
     "cyberian": ("deep_research_client.providers.cyberian", "CyberianProvider"),
     "openscientist": ("deep_research_client.providers.openscientist", "OpenScientistProvider"),
+    "deeper_med": ("deep_research_client.providers.deeper_med", "DeeperMedProvider"),
     "mock": ("deep_research_client.providers.mock", "MockProvider"),
 }
 

--- a/src/deep_research_client/model_cards.py
+++ b/src/deep_research_client/model_cards.py
@@ -541,6 +541,13 @@ def create_claude_code_model_cards() -> ProviderModelCards:
     )
 
 
+# Single source of truth for the DeepER-Med citation. Defined here rather than in
+# providers/deeper_med.py because that module imports from this one; the provider
+# re-exports it so callers can reference either.
+DEEPER_MED_ARXIV_ID = "2604.15456"
+DEEPER_MED_ARXIV_URL = f"https://arxiv.org/abs/{DEEPER_MED_ARXIV_ID}"
+
+
 def create_deeper_med_model_cards() -> ProviderModelCards:
     """Create model cards for the DeepER-Med stub provider.
 
@@ -548,6 +555,9 @@ def create_deeper_med_model_cards() -> ProviderModelCards:
     framework for medicine. No public API exists yet; this card documents the
     system so it appears in `providers` listings and so the wrapper can flip
     on once an endpoint is available.
+
+    Every attribute below is transcribed from the paper, not measured against a
+    running system -- see the ``limitations`` entries.
     """
 
     deeper_med = ModelCard(
@@ -555,13 +565,16 @@ def create_deeper_med_model_cards() -> ProviderModelCards:
         display_name="DeepER-Med Agentic Medical Research (stub)",
         description=(
             "Evidence-based agentic deep research framework for medicine "
-            "(Wang et al., arXiv:2604.15456). Decomposes queries into "
-            "hierarchical sub-questions, retrieves from PubMed, "
-            "ClinicalTrials.gov, and PrimeKG knowledge graph, and synthesizes "
-            "with traceable references retrieved directly from source databases. "
-            "STUB: no public API has been released; calls raise "
-            "NotImplementedError."
+            f"(Wang et al., arXiv:{DEEPER_MED_ARXIV_ID}). As described in the "
+            "paper: decomposes queries into hierarchical sub-questions, "
+            "retrieves from PubMed, ClinicalTrials.gov, and the PrimeKG "
+            "knowledge graph, and synthesizes with traceable references drawn "
+            "directly from source databases. STUB: no public API has been "
+            "released; calls raise NotImplementedError."
         ),
+        # Inferred from the paper's description of a multi-agent retrieval and
+        # synthesis pipeline. Nothing here has been observed -- there is no
+        # endpoint to observe.
         cost_level=CostLevel.HIGH,
         time_estimate=TimeEstimate.SLOW,
         capabilities=[
@@ -569,7 +582,7 @@ def create_deeper_med_model_cards() -> ProviderModelCards:
             ModelCapability.SCIENTIFIC_LITERATURE,
             ModelCapability.CITATION_TRACKING,
         ],
-        aliases=["deeper-med", "deeper_med", "deepermed"],
+        aliases=["deeper-med", "deepermed"],
         pricing_notes="Unknown - upstream API not yet released",
         use_cases=[
             "Evidence-based medical research synthesis",
@@ -578,8 +591,9 @@ def create_deeper_med_model_cards() -> ProviderModelCards:
             "Clinical trial evidence aggregation",
         ],
         limitations=[
-            "Stub: no upstream endpoint",
-            "Reference: https://arxiv.org/abs/2604.15456",
+            "Stub: no upstream endpoint, so this model cannot be invoked",
+            "Cost, speed, and capabilities are claims from the paper, not measured",
+            f"Reference: {DEEPER_MED_ARXIV_URL}",
         ],
     )
 

--- a/src/deep_research_client/model_cards.py
+++ b/src/deep_research_client/model_cards.py
@@ -496,6 +496,55 @@ def create_openscientist_model_cards() -> ProviderModelCards:
     )
 
 
+def create_deeper_med_model_cards() -> ProviderModelCards:
+    """Create model cards for the DeepER-Med stub provider.
+
+    DeepER-Med (arXiv:2604.15456) is an evidence-based agentic deep research
+    framework for medicine. No public API exists yet; this card documents the
+    system so it appears in `providers` listings and so the wrapper can flip
+    on once an endpoint is available.
+    """
+
+    deeper_med = ModelCard(
+        name="deeper-med-agentic",
+        display_name="DeepER-Med Agentic Medical Research (stub)",
+        description=(
+            "Evidence-based agentic deep research framework for medicine "
+            "(Wang et al., arXiv:2604.15456). Decomposes queries into "
+            "hierarchical sub-questions, retrieves from PubMed, "
+            "ClinicalTrials.gov, and PrimeKG knowledge graph, and synthesizes "
+            "with traceable references retrieved directly from source databases. "
+            "STUB: no public API has been released; calls raise "
+            "NotImplementedError."
+        ),
+        cost_level=CostLevel.HIGH,
+        time_estimate=TimeEstimate.SLOW,
+        capabilities=[
+            ModelCapability.ACADEMIC_SEARCH,
+            ModelCapability.SCIENTIFIC_LITERATURE,
+            ModelCapability.CITATION_TRACKING,
+        ],
+        aliases=["deeper-med", "deeper_med", "deepermed"],
+        pricing_notes="Unknown - upstream API not yet released",
+        use_cases=[
+            "Evidence-based medical research synthesis",
+            "Hypothesis verification grounded in PubMed",
+            "Precision oncology tumor board preparation",
+            "Clinical trial evidence aggregation",
+        ],
+        limitations=[
+            "Stub: no upstream endpoint",
+            "Reference: https://arxiv.org/abs/2604.15456",
+        ],
+    )
+
+    return ProviderModelCards(
+        provider_name="deeper_med",
+        default_model="deeper-med-agentic",
+        models={"deeper-med-agentic": deeper_med},
+    )
+
+
 # Registry of all provider model cards
 PROVIDER_MODEL_CARDS: Dict[str, ProviderModelCards] = {
     "openai": create_openai_model_cards(),
@@ -504,6 +553,7 @@ PROVIDER_MODEL_CARDS: Dict[str, ProviderModelCards] = {
     "asta": create_asta_model_cards(),
     "consensus": create_consensus_model_cards(),
     "openscientist": create_openscientist_model_cards(),
+    "deeper_med": create_deeper_med_model_cards(),
 }
 
 

--- a/src/deep_research_client/provider_params.py
+++ b/src/deep_research_client/provider_params.py
@@ -291,12 +291,11 @@ class OpenScientistParams(BaseProviderParams):
 class DeeperMedParams(BaseProviderParams):
     """Parameters specific to the DeepER-Med provider stub.
 
-    The upstream system (arXiv:2604.15456) is not yet publicly callable, so
-    these fields document the planned surface and let users construct a
-    parameter object today. They are not validated against a live API.
+    There are no provider-specific parameters yet. The upstream system
+    (arXiv:2604.15456) is not publicly callable, so its tunable surface is
+    unknown; only the inherited base fields are accepted. Fields will be added
+    here once an API is published.
     """
-
-    pass
 
 
 class CyberianParams(BaseProviderParams):

--- a/src/deep_research_client/provider_params.py
+++ b/src/deep_research_client/provider_params.py
@@ -266,6 +266,17 @@ class OpenScientistParams(BaseProviderParams):
     )
 
 
+class DeeperMedParams(BaseProviderParams):
+    """Parameters specific to the DeepER-Med provider stub.
+
+    The upstream system (arXiv:2604.15456) is not yet publicly callable, so
+    these fields document the planned surface and let users construct a
+    parameter object today. They are not validated against a live API.
+    """
+
+    pass
+
+
 class CyberianParams(BaseProviderParams):
     """Parameters specific to Cyberian agent-based research provider.
 
@@ -328,6 +339,7 @@ PROVIDER_PARAMS_REGISTRY: dict[str, Type[BaseProviderParams]] = {
     "mock": MockParams,
     "cyberian": CyberianParams,
     "openscientist": OpenScientistParams,
+    "deeper_med": DeeperMedParams,
 }
 
 

--- a/src/deep_research_client/providers/__init__.py
+++ b/src/deep_research_client/providers/__init__.py
@@ -69,6 +69,19 @@ class ResearchProvider(ABC):
         """Check if provider is available (has API key, etc.)."""
         return self.config.enabled and self.config.api_key is not None
 
+    def unavailable_reason(self) -> str:
+        """Explain why this provider is unavailable.
+
+        Called when a caller explicitly requests a provider that fails
+        :meth:`is_available`. Subclasses should override this when they can say
+        something more useful than "no API key" -- for example a stub provider
+        whose upstream service does not exist yet.
+
+        Returns:
+            Human-readable explanation suitable for an error message
+        """
+        return f"Provider '{self.name}' is not available"
+
     @property
     def name(self) -> str:
         """Get provider name."""

--- a/src/deep_research_client/providers/deeper_med.py
+++ b/src/deep_research_client/providers/deeper_med.py
@@ -1,0 +1,60 @@
+"""DeepER-Med provider stub.
+
+DeepER-Med is an evidence-based deep medical research framework introduced in
+Wang et al., "DeepER-Med: Advancing Deep Evidence-Based Research in Medicine
+Through Agentic AI" (arXiv:2604.15456, NIH/NLM, April 2026). The paper
+describes an open-source paradigm with a public website and agent API, but at
+the time of writing no code, API endpoint, or dataset has been published. This
+provider reserves the slot in the registry so the wrapper can be flipped on
+once the upstream release lands.
+
+Reference: https://arxiv.org/abs/2604.15456
+Likely upstream home: https://github.com/ncbi-nlp (Zhiyong Lu's lab)
+"""
+
+from typing import Optional
+
+from . import ResearchProvider
+from ..model_cards import ProviderModelCards, create_deeper_med_model_cards
+from ..models import ProviderConfig, ResearchResult
+from ..provider_params import DeeperMedParams
+
+DEEPER_MED_ARXIV_URL = "https://arxiv.org/abs/2604.15456"
+DEEPER_MED_UNAVAILABLE_MESSAGE = (
+    "DeepER-Med has no public API or code release yet. "
+    f"See {DEEPER_MED_ARXIV_URL} and watch https://github.com/ncbi-nlp."
+)
+
+
+class DeeperMedProvider(ResearchProvider):
+    """Placeholder provider for the DeepER-Med agentic medical research system.
+
+    The provider is registered so users can discover it and so downstream
+    integrations (CLI, model cards, params) can refer to it by name. Calling
+    :meth:`research` raises :class:`NotImplementedError` until an upstream
+    endpoint exists.
+
+    >>> provider = DeeperMedProvider(ProviderConfig(name="deeper_med"))
+    >>> provider.is_available()
+    False
+    >>> provider.get_default_model()
+    'deeper-med-agentic'
+    """
+
+    def __init__(self, config: ProviderConfig, params: Optional[DeeperMedParams] = None):
+        self.params = params or DeeperMedParams()
+        super().__init__(config, self.params.model)
+
+    def get_default_model(self) -> str:
+        return "deeper-med-agentic"
+
+    @classmethod
+    def model_cards(cls) -> ProviderModelCards:
+        return create_deeper_med_model_cards()
+
+    def is_available(self) -> bool:
+        """DeepER-Med is never available until an upstream endpoint ships."""
+        return False
+
+    async def research(self, query: str) -> ResearchResult:
+        raise NotImplementedError(DEEPER_MED_UNAVAILABLE_MESSAGE)

--- a/src/deep_research_client/providers/deeper_med.py
+++ b/src/deep_research_client/providers/deeper_med.py
@@ -2,27 +2,35 @@
 
 DeepER-Med is an evidence-based deep medical research framework introduced in
 Wang et al., "DeepER-Med: Advancing Deep Evidence-Based Research in Medicine
-Through Agentic AI" (arXiv:2604.15456, NIH/NLM, April 2026). The paper
+Through Agentic AI" (arXiv:2604.15456, submitted 16 April 2026). The paper
 describes an open-source paradigm with a public website and agent API, but at
 the time of writing no code, API endpoint, or dataset has been published. This
 provider reserves the slot in the registry so the wrapper can be flipped on
 once the upstream release lands.
 
 Reference: https://arxiv.org/abs/2604.15456
-Likely upstream home: https://github.com/ncbi-nlp (Zhiyong Lu's lab)
 """
 
 from typing import Optional
 
 from . import ResearchProvider
-from ..model_cards import ProviderModelCards, create_deeper_med_model_cards
+from ..model_cards import (
+    DEEPER_MED_ARXIV_URL,
+    ProviderModelCards,
+    create_deeper_med_model_cards,
+)
 from ..models import ProviderConfig, ResearchResult
 from ..provider_params import DeeperMedParams
 
-DEEPER_MED_ARXIV_URL = "https://arxiv.org/abs/2604.15456"
+__all__ = [
+    "DEEPER_MED_ARXIV_URL",
+    "DEEPER_MED_UNAVAILABLE_MESSAGE",
+    "DeeperMedProvider",
+]
+
 DEEPER_MED_UNAVAILABLE_MESSAGE = (
-    "DeepER-Med has no public API or code release yet. "
-    f"See {DEEPER_MED_ARXIV_URL} and watch https://github.com/ncbi-nlp."
+    "DeepER-Med has no public API or code release yet, so this provider cannot "
+    f"run research. See {DEEPER_MED_ARXIV_URL} for the paper describing it."
 )
 
 
@@ -34,27 +42,58 @@ class DeeperMedProvider(ResearchProvider):
     :meth:`research` raises :class:`NotImplementedError` until an upstream
     endpoint exists.
 
+    Because :meth:`is_available` is always ``False``, callers going through
+    :class:`~deep_research_client.client.DeepResearchClient` are rejected before
+    :meth:`research` runs; :meth:`unavailable_reason` is what carries the
+    explanation (and the arXiv pointer) out to them.
+
     >>> provider = DeeperMedProvider(ProviderConfig(name="deeper_med"))
     >>> provider.is_available()
     False
     >>> provider.get_default_model()
     'deeper-med-agentic'
+    >>> "arxiv.org" in provider.unavailable_reason()
+    True
     """
 
     def __init__(self, config: ProviderConfig, params: Optional[DeeperMedParams] = None):
+        """Initialize the stub provider.
+
+        Args:
+            config: Provider configuration (no API key is used)
+            params: Optional DeepER-Med parameters
+        """
         self.params = params or DeeperMedParams()
         super().__init__(config, self.params.model)
 
     def get_default_model(self) -> str:
+        """Return the only model card name this stub publishes."""
         return "deeper-med-agentic"
 
     @classmethod
     def model_cards(cls) -> ProviderModelCards:
+        """Return the model cards describing the (not yet callable) system."""
         return create_deeper_med_model_cards()
 
     def is_available(self) -> bool:
         """DeepER-Med is never available until an upstream endpoint ships."""
         return False
 
+    def unavailable_reason(self) -> str:
+        """Explain the stub status and point at the paper.
+
+        Overrides the generic base-class message so the arXiv reference reaches
+        users who request this provider through the client or CLI.
+        """
+        return DEEPER_MED_UNAVAILABLE_MESSAGE
+
     async def research(self, query: str) -> ResearchResult:
+        """Always raise: there is no upstream endpoint to call.
+
+        Args:
+            query: The research question (ignored)
+
+        Raises:
+            NotImplementedError: Always, with a pointer to the arXiv paper
+        """
         raise NotImplementedError(DEEPER_MED_UNAVAILABLE_MESSAGE)

--- a/tests/test_deeper_med_provider.py
+++ b/tests/test_deeper_med_provider.py
@@ -1,7 +1,10 @@
 """Tests for the DeepER-Med stub provider."""
 
 import pytest
+from typer.testing import CliRunner
 
+from deep_research_client.cli import app
+from deep_research_client.client import DeepResearchClient
 from deep_research_client.models import ProviderConfig
 from deep_research_client.provider_params import (
     DeeperMedParams,
@@ -36,7 +39,7 @@ def test_default_model_name():
     assert provider.model == "deeper-med-agentic"
 
 
-@pytest.mark.parametrize("alias", ["deeper-med", "deeper_med", "deepermed"])
+@pytest.mark.parametrize("alias", ["deeper-med", "deepermed"])
 def test_model_aliases_resolve(alias):
     provider = DeeperMedProvider(
         ProviderConfig(name="deeper_med"), DeeperMedParams(model=alias)
@@ -63,3 +66,76 @@ def test_model_card_registered():
     cards = get_provider_model_cards("deeper_med")
     assert cards is not None
     assert cards.default_model == "deeper-med-agentic"
+
+
+def test_model_card_marks_cost_and_speed_as_unmeasured():
+    """Cost/time are transcribed from the paper, so the card must say so."""
+    cards = get_provider_model_cards("deeper_med")
+    card = cards.models["deeper-med-agentic"]
+    assert any("not measured" in limit for limit in card.limitations)
+    assert any(DEEPER_MED_ARXIV_URL in limit for limit in card.limitations)
+
+
+def test_unavailable_reason_points_at_arxiv():
+    """The stub explains itself rather than falling back to the generic message."""
+    provider = DeeperMedProvider(ProviderConfig(name="deeper_med"))
+    assert DEEPER_MED_ARXIV_URL in provider.unavailable_reason()
+
+
+def test_base_provider_has_generic_unavailable_reason():
+    """Other providers keep the default wording."""
+    from deep_research_client.providers.mock import MockProvider
+
+    provider = MockProvider(ProviderConfig(name="mock", enabled=False))
+    assert provider.unavailable_reason() == "Provider 'mock' is not available"
+
+
+# --- Client-level integration of the stub ---------------------------------
+
+
+def test_client_registers_stub_without_credentials(monkeypatch):
+    """The stub is registered from a bare environment so it can be asked for."""
+    monkeypatch.delenv("ENABLE_MOCK_PROVIDER", raising=False)
+    client = DeepResearchClient()
+    assert client.registry.get_provider("deeper_med") is not None
+
+
+def test_client_never_auto_selects_the_stub(monkeypatch):
+    """Registering the stub must not make it selectable as a default provider."""
+    monkeypatch.delenv("ENABLE_MOCK_PROVIDER", raising=False)
+    client = DeepResearchClient()
+    assert "deeper_med" not in client.get_available_providers()
+    assert client.registry.get_first_available() is None or (
+        client.registry.get_first_available().name != "deeper_med"
+    )
+
+
+def test_client_research_surfaces_arxiv_pointer():
+    """Requesting the stub through the client explains why, with the citation.
+
+    This is the user-facing path the provider exists to serve: without it the
+    caller would only see a bare "provider not found" / "is not available".
+    """
+    client = DeepResearchClient()
+    with pytest.raises(ValueError) as excinfo:
+        client.research("What causes glioblastoma?", provider="deeper_med")
+    assert DEEPER_MED_ARXIV_URL in str(excinfo.value)
+
+
+# --- CLI discoverability --------------------------------------------------
+
+
+def test_cli_lists_stub_provider():
+    """`providers` must surface the stub; you shouldn't need to know the name."""
+    result = CliRunner().invoke(app, ["providers"])
+    assert result.exit_code == 0
+    assert "deeper_med" in result.stdout
+    assert "Stub providers" in result.stdout
+
+
+def test_cli_stub_detail_does_not_claim_missing_api_key():
+    """A stub is not credential-blocked, so it must not ask for a key."""
+    result = CliRunner().invoke(app, ["providers", "--provider", "deeper_med"])
+    assert result.exit_code == 0
+    assert "stub - no upstream API yet" in result.stdout
+    assert "missing API key" not in result.stdout

--- a/tests/test_deeper_med_provider.py
+++ b/tests/test_deeper_med_provider.py
@@ -1,0 +1,65 @@
+"""Tests for the DeepER-Med stub provider."""
+
+import pytest
+
+from deep_research_client.models import ProviderConfig
+from deep_research_client.provider_params import (
+    DeeperMedParams,
+    create_provider_params,
+    get_provider_params_class,
+)
+from deep_research_client.providers.deeper_med import (
+    DEEPER_MED_ARXIV_URL,
+    DeeperMedProvider,
+)
+from deep_research_client.model_cards import (
+    PROVIDER_MODEL_CARDS,
+    get_provider_model_cards,
+)
+
+
+def test_provider_is_unavailable_by_default():
+    provider = DeeperMedProvider(ProviderConfig(name="deeper_med"))
+    assert provider.is_available() is False
+
+
+def test_provider_is_unavailable_even_with_api_key():
+    """Stub stays disabled until an upstream endpoint exists."""
+    provider = DeeperMedProvider(
+        ProviderConfig(name="deeper_med", api_key="placeholder")
+    )
+    assert provider.is_available() is False
+
+
+def test_default_model_name():
+    provider = DeeperMedProvider(ProviderConfig(name="deeper_med"))
+    assert provider.model == "deeper-med-agentic"
+
+
+@pytest.mark.parametrize("alias", ["deeper-med", "deeper_med", "deepermed"])
+def test_model_aliases_resolve(alias):
+    provider = DeeperMedProvider(
+        ProviderConfig(name="deeper_med"), DeeperMedParams(model=alias)
+    )
+    assert provider.model == "deeper-med-agentic"
+
+
+@pytest.mark.asyncio
+async def test_research_raises_with_arxiv_pointer():
+    provider = DeeperMedProvider(ProviderConfig(name="deeper_med"))
+    with pytest.raises(NotImplementedError) as excinfo:
+        await provider.research("What causes glioblastoma?")
+    assert DEEPER_MED_ARXIV_URL in str(excinfo.value)
+
+
+def test_provider_params_registered():
+    assert get_provider_params_class("deeper_med") is DeeperMedParams
+    params = create_provider_params("deeper_med")
+    assert isinstance(params, DeeperMedParams)
+
+
+def test_model_card_registered():
+    assert "deeper_med" in PROVIDER_MODEL_CARDS
+    cards = get_provider_model_cards("deeper_med")
+    assert cards is not None
+    assert cards.default_model == "deeper-med-agentic"

--- a/tests/test_deeper_med_provider.py
+++ b/tests/test_deeper_med_provider.py
@@ -5,7 +5,7 @@ from typer.testing import CliRunner
 
 from deep_research_client.cli import app
 from deep_research_client.client import DeepResearchClient
-from deep_research_client.models import ProviderConfig
+from deep_research_client.models import CacheConfig, ProviderConfig
 from deep_research_client.provider_params import (
     DeeperMedParams,
     create_provider_params,
@@ -96,14 +96,14 @@ def test_base_provider_has_generic_unavailable_reason():
 def test_client_registers_stub_without_credentials(monkeypatch):
     """The stub is registered from a bare environment so it can be asked for."""
     monkeypatch.delenv("ENABLE_MOCK_PROVIDER", raising=False)
-    client = DeepResearchClient()
+    client = DeepResearchClient(cache_config=CacheConfig(enabled=False))
     assert client.registry.get_provider("deeper_med") is not None
 
 
 def test_client_never_auto_selects_the_stub(monkeypatch):
     """Registering the stub must not make it selectable as a default provider."""
     monkeypatch.delenv("ENABLE_MOCK_PROVIDER", raising=False)
-    client = DeepResearchClient()
+    client = DeepResearchClient(cache_config=CacheConfig(enabled=False))
     assert "deeper_med" not in client.get_available_providers()
     assert client.registry.get_first_available() is None or (
         client.registry.get_first_available().name != "deeper_med"
@@ -116,7 +116,7 @@ def test_client_research_surfaces_arxiv_pointer():
     This is the user-facing path the provider exists to serve: without it the
     caller would only see a bare "provider not found" / "is not available".
     """
-    client = DeepResearchClient()
+    client = DeepResearchClient(cache_config=CacheConfig(enabled=False))
     with pytest.raises(ValueError) as excinfo:
         client.research("What causes glioblastoma?", provider="deeper_med")
     assert DEEPER_MED_ARXIV_URL in str(excinfo.value)


### PR DESCRIPTION
DeepER-Med (Wang et al., arXiv:2604.15456) is an evidence-based agentic
deep medical research framework. The paper describes an open-source
release with a public website and agent API, but no code, endpoint, or
dataset is publicly available yet.

Reserve the provider slot now so:
- the name is discoverable in `providers` listings,
- model cards and Pydantic params are in place,
- callers get a clear explanation pointing at the arXiv paper instead of an
  opaque "provider not found".

`is_available()` returns False, so the stub can never be auto-selected by
`get_first_available()`. Once the upstream API ships, only the body of
`providers/deeper_med.py` needs to change.

## How the stub surfaces to users

Requesting it explicitly through the client reports why it cannot run:

```
>>> client.research("...", provider="deeper_med")
ValueError: DeepER-Med has no public API or code release yet, so this provider
cannot run research. See https://arxiv.org/abs/2604.15456 for the paper describing it.
```

This works via a new `ResearchProvider.unavailable_reason()` hook, which
defaults to the previous generic wording for every other provider. In the CLI
the stub is listed under **Stub providers (not yet callable)** rather than
being mixed into the missing-credentials section, since no key can enable it.

## Citation

`arXiv:2604.15456` was verified by hand against the arXiv listing:
*"DeepER-Med: Advancing Deep Evidence-Based Research in Medicine Through
Agentic AI"*, submitted 16 April 2026, Zhizheng Wang, Chih-Hsuan Wei, …
Zhiyong Lu. The ID ships inside a runtime error message and a CLI hint, so it
is consolidated into a single `DEEPER_MED_ARXIV_URL` / `DEEPER_MED_ARXIV_ID`
constant in `model_cards.py`.

An earlier revision guessed at `github.com/ncbi-nlp` as the "likely upstream
home" and attributed it to a named researcher's lab; that speculation has been
removed from both the error message and the docs.

## Deliberate omissions from the provider checklist

`CLAUDE.md` asks for integration tests and README documentation. Both are
intentionally skipped here rather than overlooked:

- **No integration tests.** There is no endpoint to integrate against. The unit
  tests cover the client-level path, both CLI surfaces, and the model card.
- **No README entry.** The README provider lists read as "providers you can
  use"; a permanently unavailable stub would misrepresent itself there. It
  should be added — at `README.md:7`, `README.md:11`, and the Supported
  Providers table — when the upstream API actually ships.

The model card's cost, speed, and capability values are transcribed from the
paper, not measured, and the card's `limitations` say so explicitly.
