### PR TITLE
Drop deprecated `title` field from OpenScientist job submission

### DIFF
--- a/src/deep_research_client/providers/openscientist.py
+++ b/src/deep_research_client/providers/openscientist.py
@@ -76,7 +76,7 @@ class OpenScientistProvider(ResearchProvider):
         """Submit a research job, poll until completion, and return the report.
 
         Args:
-            query: The research question (used as both title and research_question).
+            query: The research question sent to the OpenScientist agent.
 
         Returns:
             ResearchResult with markdown report and extracted PMID citations.
@@ -166,11 +166,7 @@ class OpenScientistProvider(ResearchProvider):
         """Submit a research job and return the job ID."""
         url = f"{self.base_url}/api/v1/jobs"
 
-        # Generate a concise title from the query
-        title = query[:255] if len(query) <= 255 else query[:252] + "..."
-
         payload = {
-            "title": title,
             "research_question": query,
             "max_iterations": max_iterations,
             "use_hypotheses": self.params.use_hypotheses,


### PR DESCRIPTION
## Summary

OpenScientist removed the `title` field from `JobCreate` in [openscientist-io/openscientist#110](https://github.com/openscientist-io/openscientist/pull/110), deployed to production on 2026-05-04. Drop the corresponding dead-code field from this client's job submission payload.

## What changes

`src/deep_research_client/providers/openscientist.py:160-178`:

- Remove the `"title": title` entry from the POST payload and the truncation helper that built it.
- Update the docstring (`query` no longer maps to both fields — only `research_question`).

## Why this is safe

Pydantic's default `extra="ignore"` silently drops unknown fields, so the API has continued to work since the OpenScientist deploy — this is pure cleanup, not a hotfix. The local `title` was only ever a truncated copy of `query`, so no semantic information is lost.

## What's NOT in this PR

- **Not setting `short_title`.** OpenScientist's agent overwrites any user-supplied `short_title` with its own AI-generated label during the run, so client-side `short_title` would be redundant. The dismech proxy worker (separate codebase) does set `short_title` because it has a meaningful disease-name-prefixed label to surface; this generic client doesn't.
- **No version bump in this PR.** Maintainers should cut a release after merge — downstream consumers like dismech's `.venv` need to `uv sync` to pick this up.

## Test plan

- [x] `uv run pytest tests/test_openscientist_provider.py -x` — 20 passed.
- [x] `uv run ruff check src/deep_research_client/providers/openscientist.py` — clean.
- [x] `uv run mypy src/deep_research_client/providers/openscientist.py` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
