### PR TITLE
Preserve Edison output artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -897,10 +897,12 @@ deep-research-client research "simple question" --provider perplexity --model so
 | Provider | Environment Variable | Model/Service | Strengths |
 |----------|---------------------|---------------|-----------|
 | OpenAI | `OPENAI_API_KEY` | o3-deep-research-2025-06-26 | Deep research, comprehensive reports |
-| Edison | `EDISON_API_KEY` | Edison Scientific Literature | Scientific literature focus, powered by PaperQA3 |
+| Edison | `EDISON_API_KEY` | Edison Scientific Literature | Scientific literature focus, powered by PaperQA3; preserves output figures and files |
 | Perplexity | `PERPLEXITY_API_KEY` | sonar-deep-research | Real-time web search, recent sources |
 | Consensus | `CONSENSUS_API_KEY` | Consensus Academic Search | Peer-reviewed academic papers, evidence-based research |
 | OpenScientist | `OPENSCIENTIST_API_KEY` | openscientist-autonomous | Iterative hypothesis-driven research, PubMed PMID citations |
+
+When Edison produces diagrams, charts, figures, or other output artifacts, saved reports include an `Artifacts` section. Image artifacts are written to a sidecar directory such as `report_artifacts/` and embedded with relative Markdown links.
 
 ## Development
 

--- a/docs/explanation/ralph-wiggum-deep-research.md
+++ b/docs/explanation/ralph-wiggum-deep-research.md
@@ -25,7 +25,7 @@ The name comes from [Ralph Wiggum](https://en.wikipedia.org/wiki/Ralph_Wiggum), 
 
 So Ralph can code. But can he do a literature review?
 
-The [cyberian](https://github.com/monarch-initiative/cyberian) provider in [deep-research-client](https://github.com/monarch-initiative/deep-research-client) runs a similar autonomous loop, but instead of iterating on code until tests pass, it iterates on research until the literature is exhausted. The workflow is defined in [deep-research.yaml](../workflows/deep-research.yaml):
+The [cyberian](https://github.com/monarch-initiative/cyberian) provider in [deep-research-client](https://github.com/monarch-initiative/deep-research-client) runs a similar autonomous loop, but instead of iterating on code until tests pass, it iterates on research until the literature is exhausted. The workflow is defined in [deep-research.yaml](https://github.com/monarch-initiative/deep-research-client/blob/main/src/deep_research_client/workflows/deep-research.yaml):
 
 ```yaml
 subtasks:

--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -126,6 +126,7 @@ params = FalconParams(
 - **Cost**: High
 - **Speed**: 2-5 minutes
 - **Capabilities**: Scientific literature, powered by PaperQA3
+- **Artifacts**: Edison output artifacts are fetched from the completed task. Image artifacts such as diagrams, charts, and figures are written beside saved reports and embedded in the generated Markdown; other artifact files are linked from an `Artifacts` section.
 
 ---
 

--- a/src/deep_research_client/cli.py
+++ b/src/deep_research_client/cli.py
@@ -21,7 +21,7 @@ from .model_cards import (
     TimeEstimate,
     ModelCapability
 )
-from .models import ResearchResult
+from .models import ResearchResult, sanitize_artifact_filename
 
 # Configure logging
 logger = logging.getLogger("deep_research_client")
@@ -187,7 +187,7 @@ def _effective_research_options(
 
 def _unique_artifact_filename(filename: str, used_filenames: set[str], index: int) -> str:
     """Return a filesystem-safe artifact filename unique within one result."""
-    safe_name = Path(filename).name.strip() or f"artifact-{index}"
+    safe_name = sanitize_artifact_filename(filename, fallback=f"artifact-{index}")
     if safe_name in {".", ".."}:
         safe_name = f"artifact-{index}"
 

--- a/src/deep_research_client/cli.py
+++ b/src/deep_research_client/cli.py
@@ -1,6 +1,7 @@
 """CLI interface for deep-research-client."""
 
 import base64
+import binascii
 from dataclasses import dataclass
 import logging
 import os
@@ -214,7 +215,11 @@ def _write_result_artifacts(result: ResearchResult, output: Path) -> None:
     for index, artifact in enumerate(result.artifacts, 1):
         filename = _unique_artifact_filename(artifact.filename, used_filenames, index)
         artifact_path = artifact_dir / filename
-        artifact_path.write_bytes(base64.b64decode(artifact.content_base64))
+        try:
+            content = base64.b64decode(artifact.content_base64, validate=True)
+        except (binascii.Error, ValueError) as exc:
+            raise ValueError(f"Invalid base64 content for artifact {artifact.filename}") from exc
+        artifact_path.write_bytes(content)
         artifact.path = artifact_path.relative_to(output.parent).as_posix()
 
 

--- a/src/deep_research_client/cli.py
+++ b/src/deep_research_client/cli.py
@@ -1,5 +1,6 @@
 """CLI interface for deep-research-client."""
 
+import base64
 from dataclasses import dataclass
 import logging
 import os
@@ -19,12 +20,23 @@ from .model_cards import (
     TimeEstimate,
     ModelCapability
 )
+from .models import ResearchResult
 
 # Configure logging
 logger = logging.getLogger("deep_research_client")
 
 app = typer.Typer(
     help="deep-research-client: Wrapper for multiple deep research tools")
+
+PROVIDER_CREDENTIAL_HINTS = {
+    "openai": ("OPENAI_API_KEY", "OpenAI Deep Research"),
+    "falcon": ("EDISON_API_KEY", "Edison Scientific"),
+    "asta": ("ASTA_API_KEY", "Asta"),
+    "perplexity": ("PERPLEXITY_API_KEY", "Perplexity AI"),
+    "consensus": ("CONSENSUS_API_KEY", "Consensus"),
+    "openscientist": ("OPENSCIENTIST_API_KEY", "OpenScientist"),
+    "mock": ("ENABLE_MOCK_PROVIDER=true", "Mock provider"),
+}
 
 
 def setup_logging(verbosity: int) -> None:
@@ -170,6 +182,47 @@ def _effective_research_options(
         api_key_env=api_key_env,
         warnings=warnings,
     )
+
+
+def _unique_artifact_filename(filename: str, used_filenames: set[str], index: int) -> str:
+    """Return a filesystem-safe artifact filename unique within one result."""
+    safe_name = Path(filename).name.strip() or f"artifact-{index}"
+    if safe_name in {".", ".."}:
+        safe_name = f"artifact-{index}"
+
+    candidate = safe_name
+    suffix = Path(safe_name).suffix
+    stem = Path(safe_name).stem or f"artifact-{index}"
+    counter = 2
+    while candidate in used_filenames:
+        candidate = f"{stem}-{counter}{suffix}"
+        counter += 1
+
+    used_filenames.add(candidate)
+    return candidate
+
+
+def _write_result_artifacts(result: ResearchResult, output: Path) -> None:
+    """Write research artifacts beside a report and set their relative paths."""
+    if not result.artifacts:
+        return
+
+    artifact_dir = output.parent / f"{output.stem}_artifacts"
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+
+    used_filenames: set[str] = set()
+    for index, artifact in enumerate(result.artifacts, 1):
+        filename = _unique_artifact_filename(artifact.filename, used_filenames, index)
+        artifact_path = artifact_dir / filename
+        artifact_path.write_bytes(base64.b64decode(artifact.content_base64))
+        artifact.path = artifact_path.relative_to(output.parent).as_posix()
+
+
+def _echo_credential_hints(provider_names: list[str]) -> None:
+    """Print credential hints for providers by canonical provider name."""
+    for provider_name in provider_names:
+        env_var, label = PROVIDER_CREDENTIAL_HINTS[provider_name]
+        typer.echo(f"  - {env_var} for {label}")
 
 
 @app.callback()
@@ -464,6 +517,9 @@ def research(
         # Determine if we're separating citations
         should_separate_citations = separate_citations is not None
 
+        if output:
+            _write_result_artifacts(result, output)
+
         # Format output using processor
         logger.debug("Formatting research result")
         output_content = processor.format_research_result(
@@ -537,17 +593,9 @@ def providers(
 
         if not is_available:
             # Show required environment variable
-            env_vars = {
-                "openai": "OPENAI_API_KEY",
-                "falcon": "EDISON_API_KEY",
-                "asta": "ASTA_API_KEY",
-                "perplexity": "PERPLEXITY_API_KEY",
-                "consensus": "CONSENSUS_API_KEY",
-                "openscientist": "OPENSCIENTIST_API_KEY",
-                "mock": "ENABLE_MOCK_PROVIDER=true"
-            }
-            if provider in env_vars:
-                typer.echo(f"Required: {env_vars[provider]}")
+            if provider in PROVIDER_CREDENTIAL_HINTS:
+                env_var = PROVIDER_CREDENTIAL_HINTS[provider][0]
+                typer.echo(f"Required: {env_var}")
 
         # Show parameters
         params_class = PROVIDER_PARAMS_REGISTRY[provider]
@@ -586,15 +634,18 @@ def providers(
                             continue
                         typer.echo(
                             f"    {field_name}: {field_info.description}")
+
+        missing_credential_providers = [
+            provider_name
+            for provider_name in PROVIDER_CREDENTIAL_HINTS
+            if provider_name not in available
+        ]
+        if missing_credential_providers:
+            typer.echo("\nUnavailable providers requiring credentials:")
+            _echo_credential_hints(missing_credential_providers)
     else:
         logger.error("No providers available. Please set API keys:")
-        typer.echo("  - OPENAI_API_KEY for OpenAI Deep Research")
-        typer.echo("  - EDISON_API_KEY for Edison Scientific")
-        typer.echo("  - ASTA_API_KEY for Asta")
-        typer.echo("  - PERPLEXITY_API_KEY for Perplexity AI")
-        typer.echo("  - CONSENSUS_API_KEY for Consensus")
-        typer.echo("  - OPENSCIENTIST_API_KEY for OpenScientist")
-        typer.echo("  - ENABLE_MOCK_PROVIDER=true for Mock provider")
+        _echo_credential_hints(list(PROVIDER_CREDENTIAL_HINTS))
 
     if not show_params and not provider:
         typer.echo(

--- a/src/deep_research_client/client.py
+++ b/src/deep_research_client/client.py
@@ -210,6 +210,8 @@ class DeepResearchClient:
         # keep stale cache entries from shadowing current live results.
         if research_provider.name == "asta":
             effective_params["_cache_version"] = "snippet-v5"
+        elif research_provider.name == "falcon":
+            effective_params["_cache_version"] = "artifacts-v1"
 
         return effective_params or None
 

--- a/src/deep_research_client/formatter.py
+++ b/src/deep_research_client/formatter.py
@@ -52,6 +52,20 @@ class ResultFormatter:
         if result.citations:
             metadata["citation_count"] = len(result.citations)
 
+        if result.artifacts:
+            metadata["artifact_count"] = len(result.artifacts)
+            metadata["artifacts"] = [
+                {
+                    "filename": artifact.filename,
+                    "path": artifact.path or artifact.filename,
+                    "media_type": artifact.media_type,
+                    "source": artifact.source,
+                    "data_storage_id": artifact.data_storage_id,
+                    "description": artifact.description,
+                }
+                for artifact in result.artifacts
+            ]
+
         # Convert metadata to YAML frontmatter
         frontmatter_yaml = yaml.dump(metadata, default_flow_style=False, sort_keys=False)
 
@@ -74,6 +88,18 @@ class ResultFormatter:
         parts.append("## Output")
         parts.append("")
         parts.append(result.markdown)
+
+        if result.artifacts:
+            parts.append("")
+            parts.append("## Artifacts")
+            parts.append("")
+            for artifact in result.artifacts:
+                artifact_path = artifact.path or artifact.filename
+                label = artifact.description or artifact.filename
+                if artifact.is_image:
+                    parts.append(f"![{label}]({artifact_path})")
+                else:
+                    parts.append(f"- [{label}]({artifact_path})")
 
         # Add citations section (unless separated)
         if result.citations and not separate_citations:

--- a/src/deep_research_client/models.py
+++ b/src/deep_research_client/models.py
@@ -2,7 +2,22 @@
 
 from typing import List, Optional, Dict, Any
 from datetime import datetime
-from pydantic import BaseModel, Field
+import re
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+
+MAX_ARTIFACT_BYTES = 50 * 1024 * 1024
+_UNSAFE_ARTIFACT_FILENAME_CHARS = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
+_REPEATED_UNDERSCORES = re.compile(r"_+")
+
+
+def sanitize_artifact_filename(raw_name: str, fallback: str = "artifact") -> str:
+    """Return a filesystem-safe basename for an artifact filename."""
+    safe_name = _UNSAFE_ARTIFACT_FILENAME_CHARS.sub("_", str(raw_name or fallback))
+    safe_name = safe_name.replace("..", "_").strip(". ")
+    safe_name = _REPEATED_UNDERSCORES.sub("_", safe_name)
+    return safe_name or fallback
 
 
 class EditHistoryEntry(BaseModel):
@@ -30,6 +45,23 @@ class ResearchArtifact(BaseModel):
     source: Optional[str] = Field(default=None, description="Provider-specific artifact source")
     data_storage_id: Optional[str] = Field(default=None, description="Provider data storage identifier")
     description: Optional[str] = Field(default=None, description="Human-readable artifact description")
+
+    @field_validator("filename")
+    @classmethod
+    def sanitize_filename(cls, value: str) -> str:
+        """Sanitize artifact filenames before they reach filesystem output."""
+        return sanitize_artifact_filename(value)
+
+    @model_validator(mode="after")
+    def validate_artifact_size(self) -> "ResearchArtifact":
+        """Reject artifacts that are too large to safely hold in memory."""
+        estimated_size = len(self.content_base64) * 3 // 4
+        if estimated_size > MAX_ARTIFACT_BYTES:
+            raise ValueError(
+                f"Artifact too large: estimated {estimated_size} bytes exceeds "
+                f"{MAX_ARTIFACT_BYTES} byte limit"
+            )
+        return self
 
     @property
     def is_image(self) -> bool:

--- a/src/deep_research_client/models.py
+++ b/src/deep_research_client/models.py
@@ -20,11 +20,29 @@ class QueryMetadata(BaseModel):
     contributors: List[str] = Field(default_factory=list, description="List of contributors")
 
 
+class ResearchArtifact(BaseModel):
+    """A non-text artifact produced alongside a research report."""
+
+    filename: str = Field(..., description="Artifact filename")
+    content_base64: str = Field(..., description="Base64-encoded artifact content")
+    media_type: Optional[str] = Field(default=None, description="Artifact MIME/media type")
+    path: Optional[str] = Field(default=None, description="Relative path used in formatted markdown")
+    source: Optional[str] = Field(default=None, description="Provider-specific artifact source")
+    data_storage_id: Optional[str] = Field(default=None, description="Provider data storage identifier")
+    description: Optional[str] = Field(default=None, description="Human-readable artifact description")
+
+    @property
+    def is_image(self) -> bool:
+        """Return whether this artifact can be embedded as a Markdown image."""
+        return (self.media_type or "").startswith("image/")
+
+
 class ResearchResult(BaseModel):
     """Result from a deep research query."""
 
     markdown: str = Field(..., description="Research report in markdown format")
     citations: List[str] = Field(default_factory=list, description="List of citations/references")
+    artifacts: List[ResearchArtifact] = Field(default_factory=list, description="Non-text artifacts produced with the report")
     provider: str = Field(..., description="Name of the research provider used")
     cached: bool = Field(default=False, description="Whether result was retrieved from cache")
     query: str = Field(..., description="Original query that generated this result")

--- a/src/deep_research_client/processing/result_formatter.py
+++ b/src/deep_research_client/processing/result_formatter.py
@@ -66,6 +66,20 @@ class ResultFormatter:
         if result.citations:
             metadata["citation_count"] = len(result.citations)
 
+        if result.artifacts:
+            metadata["artifact_count"] = len(result.artifacts)
+            metadata["artifacts"] = [
+                {
+                    "filename": artifact.filename,
+                    "path": artifact.path or artifact.filename,
+                    "media_type": artifact.media_type,
+                    "source": artifact.source,
+                    "data_storage_id": artifact.data_storage_id,
+                    "description": artifact.description,
+                }
+                for artifact in result.artifacts
+            ]
+
         # Add edit history if present
         if result.edit_history:
             metadata["edit_history"] = [
@@ -99,6 +113,18 @@ class ResultFormatter:
         parts.append("## Output")
         parts.append("")
         parts.append(result.markdown)
+
+        if result.artifacts:
+            parts.append("")
+            parts.append("## Artifacts")
+            parts.append("")
+            for artifact in result.artifacts:
+                artifact_path = artifact.path or artifact.filename
+                label = artifact.description or artifact.filename
+                if artifact.is_image:
+                    parts.append(f"![{label}]({artifact_path})")
+                else:
+                    parts.append(f"- [{label}]({artifact_path})")
 
         # Add citations section (unless separated)
         if result.citations and not separate_citations:

--- a/src/deep_research_client/providers/falcon.py
+++ b/src/deep_research_client/providers/falcon.py
@@ -1,6 +1,7 @@
 """Edison Scientific provider (formerly FutureHouse Falcon)."""
 
 import base64
+import json
 import logging
 import mimetypes
 import re
@@ -192,9 +193,9 @@ class FalconProvider(ResearchProvider):
             return []
 
         output_data = self._extract_output_data(task_response.environment_frame or {})
-        artifacts: list[ResearchArtifact] = []
+        artifacts = self._extract_answer_artifacts(task_response)
         used_storage_ids: set[str] = set()
-        used_filenames: set[str] = set()
+        used_filenames: set[str] = {artifact.filename for artifact in artifacts}
 
         for item in output_data:
             storage_id = self._get_data_storage_id(item)
@@ -215,6 +216,70 @@ class FalconProvider(ResearchProvider):
                 artifacts.append(artifact)
 
         return artifacts
+
+    def _extract_answer_artifacts(
+        self,
+        response: TaskResponseVerbose,
+    ) -> list[ResearchArtifact]:
+        """Extract artifacts embedded directly in a verbose Edison answer."""
+        answer = self._get_verbose_answer(response)
+        raw_artifacts = answer.get("artifacts")
+        if not isinstance(raw_artifacts, dict):
+            return []
+
+        artifacts: list[ResearchArtifact] = []
+        used_filenames: set[str] = set()
+        for raw_name, raw_content in raw_artifacts.items():
+            artifact = self._artifact_from_answer_value(
+                raw_name=str(raw_name),
+                raw_content=raw_content,
+                used_filenames=used_filenames,
+            )
+            if artifact is not None:
+                artifacts.append(artifact)
+
+        return artifacts
+
+    def _artifact_from_answer_value(
+        self,
+        raw_name: str,
+        raw_content: Any,
+        used_filenames: set[str],
+    ) -> ResearchArtifact | None:
+        """Convert an Edison answer artifact value into a research artifact."""
+        if isinstance(raw_content, dict) and isinstance(raw_content.get("content_base64"), str):
+            filename = self._artifact_filename(
+                raw_content.get("filename") or raw_name,
+                used_filenames,
+            )
+            return ResearchArtifact(
+                filename=filename,
+                content_base64=raw_content["content_base64"],
+                media_type=raw_content.get("media_type") or mimetypes.guess_type(filename)[0],
+                source="edison_answer_artifacts",
+                description=raw_content.get("description") or f"Edison artifact {raw_name}",
+            )
+
+        if isinstance(raw_content, str):
+            filename = self._filename_with_default_suffix(raw_name, ".md")
+            filename = self._artifact_filename(filename, used_filenames)
+            media_type = "text/markdown"
+            content = raw_content.encode("utf-8")
+        elif raw_content is None:
+            return None
+        else:
+            filename = self._filename_with_default_suffix(raw_name, ".json")
+            filename = self._artifact_filename(filename, used_filenames)
+            media_type = "application/json"
+            content = json.dumps(raw_content, indent=2, sort_keys=True).encode("utf-8")
+
+        return ResearchArtifact(
+            filename=filename,
+            content_base64=base64.b64encode(content).decode("ascii"),
+            media_type=media_type,
+            source="edison_answer_artifacts",
+            description=f"Edison artifact {raw_name}",
+        )
 
     def _extract_output_data(self, environment_frame: dict[str, Any]) -> list[dict[str, Any]]:
         """Extract Edison output_data entries from an environment frame."""
@@ -343,6 +408,13 @@ class FalconProvider(ResearchProvider):
 
         used_filenames.add(candidate)
         return candidate
+
+    def _filename_with_default_suffix(self, raw_name: str, suffix: str) -> str:
+        """Add a suffix to an artifact name if Edison did not provide one."""
+        path = Path(raw_name)
+        if path.suffix:
+            return raw_name
+        return f"{raw_name}{suffix}"
 
     def _make_artifact(
         self,

--- a/src/deep_research_client/providers/falcon.py
+++ b/src/deep_research_client/providers/falcon.py
@@ -1,14 +1,19 @@
 """Edison Scientific provider (formerly FutureHouse Falcon)."""
 
+import base64
 import logging
+import mimetypes
 import re
-from typing import List, Optional
+from pathlib import Path
+from typing import Any, Iterable, List, Optional
+from uuid import UUID
 
 from edison_client import EdisonClient, JobNames
-from edison_client.models.app import PQATaskResponse
+from edison_client.models.app import PQATaskResponse, TaskResponseVerbose
+from edison_client.models.data_storage_methods import RawFetchResponse
 
 from . import ResearchProvider
-from ..models import ResearchResult, ProviderConfig
+from ..models import ResearchArtifact, ResearchResult, ProviderConfig
 from ..provider_params import FalconParams
 from ..model_cards import ProviderModelCards, create_falcon_model_cards
 from ..system_prompts import DEFAULT_RESEARCH_SYSTEM_PROMPT
@@ -62,7 +67,7 @@ class FalconProvider(ResearchProvider):
 
         try:
             logger.debug("Making API request to Edison")
-            response = client.run_tasks_until_done(task_data)
+            response = client.run_tasks_until_done(task_data, verbose=True)
             logger.info("Edison API request completed successfully")
 
             # Extract the report text and citations
@@ -72,9 +77,13 @@ class FalconProvider(ResearchProvider):
             citations = self._extract_citations(response, markdown_content)
             logger.info(f"Extracted {len(citations)} citations from response")
 
+            artifacts = self._extract_artifacts(client, response)
+            logger.info(f"Extracted {len(artifacts)} artifacts from response")
+
             return ResearchResult(
                 markdown=markdown_content,
                 citations=citations,
+                artifacts=artifacts,
                 provider=self.name,
                 query=query
             )
@@ -86,18 +95,28 @@ class FalconProvider(ResearchProvider):
     def _extract_text_content(self, response) -> str:
         """Extract text content from Edison response.
 
-        Edison returns PQATaskResponse objects with 'formatted_answer' (preferred)
-        and 'answer' fields.
+        Edison returns PQATaskResponse objects for standard calls. With
+        verbose=True, it returns TaskResponseVerbose objects and the answer must
+        be read from the final environment frame.
         """
         if not isinstance(response, list) or len(response) == 0:
             raise ValueError(f"Unexpected Edison response structure: {type(response)}")
 
         task_response = response[0]
 
-        # Edison always returns PQATaskResponse - fail fast if it doesn't
+        if isinstance(task_response, TaskResponseVerbose):
+            answer = self._get_verbose_answer(task_response)
+            if formatted_answer := answer.get("formatted_answer"):
+                return str(formatted_answer)
+            if plain_answer := answer.get("answer"):
+                return str(plain_answer)
+            raise ValueError(
+                f"Verbose Edison response has no answer. Status: {task_response.status}"
+            )
+
         if not isinstance(task_response, PQATaskResponse):
             raise ValueError(
-                f"Expected PQATaskResponse, got {type(task_response)}. "
+                f"Expected PQATaskResponse or TaskResponseVerbose, got {type(task_response)}. "
                 f"This indicates an API change in edison-client."
             )
 
@@ -111,6 +130,26 @@ class FalconProvider(ResearchProvider):
                 f"PQATaskResponse has no answer. Status: {task_response.status}, "
                 f"has_successful_answer: {task_response.has_successful_answer}"
             )
+
+    def _get_verbose_answer(self, response: TaskResponseVerbose) -> dict[str, Any]:
+        """Extract the answer object from a verbose Edison response."""
+        environment_frame = response.environment_frame or {}
+        state = environment_frame.get("state", {})
+        nested_state = state.get("state", {})
+
+        response_answer = (
+            nested_state
+            .get("response", {})
+            .get("answer", {})
+        )
+        if isinstance(response_answer, dict):
+            return response_answer
+
+        direct_answer = nested_state.get("answer")
+        if isinstance(direct_answer, str):
+            return {"answer": direct_answer}
+
+        return {}
 
     def _extract_citations(self, response, report_text: str) -> List[str]:
         """Extract citations from Edison response.
@@ -142,3 +181,183 @@ class FalconProvider(ResearchProvider):
             return unique_citations
 
         return []
+
+    def _extract_artifacts(self, client: EdisonClient, response: list[Any]) -> list[ResearchArtifact]:
+        """Fetch artifacts listed in the final Edison environment frame."""
+        if not response:
+            return []
+
+        task_response = response[0]
+        if not isinstance(task_response, TaskResponseVerbose):
+            return []
+
+        output_data = self._extract_output_data(task_response.environment_frame or {})
+        artifacts: list[ResearchArtifact] = []
+        used_storage_ids: set[str] = set()
+        used_filenames: set[str] = set()
+
+        for item in output_data:
+            storage_id = self._get_data_storage_id(item)
+            if storage_id is None:
+                logger.debug(f"Skipping Edison artifact without entry_id: {item}")
+                continue
+            if str(storage_id) in used_storage_ids:
+                continue
+            used_storage_ids.add(str(storage_id))
+
+            fetched = client.fetch_data_from_storage(data_storage_id=storage_id)
+            for artifact in self._artifacts_from_fetch_response(
+                fetched,
+                source_item=item,
+                storage_id=storage_id,
+                used_filenames=used_filenames,
+            ):
+                artifacts.append(artifact)
+
+        return artifacts
+
+    def _extract_output_data(self, environment_frame: dict[str, Any]) -> list[dict[str, Any]]:
+        """Extract Edison output_data entries from an environment frame."""
+        direct_output_data = (
+            environment_frame
+            .get("state", {})
+            .get("info", {})
+            .get("output_data")
+        )
+        if isinstance(direct_output_data, list):
+            return [item for item in direct_output_data if isinstance(item, dict)]
+
+        output_data: list[dict[str, Any]] = []
+        for value in self._walk_values(environment_frame):
+            if isinstance(value, dict) and isinstance(value.get("output_data"), list):
+                output_data.extend(
+                    item for item in value["output_data"] if isinstance(item, dict)
+                )
+
+        return output_data
+
+    def _walk_values(self, value: Any) -> Iterable[Any]:
+        """Yield nested dict and list values."""
+        yield value
+        if isinstance(value, dict):
+            for nested_value in value.values():
+                yield from self._walk_values(nested_value)
+        elif isinstance(value, list):
+            for nested_value in value:
+                yield from self._walk_values(nested_value)
+
+    def _get_data_storage_id(self, item: dict[str, Any]) -> UUID | None:
+        """Extract a data-storage UUID from an Edison output_data item."""
+        raw_id = item.get("entry_id") or item.get("data_storage_id") or item.get("id")
+        if raw_id is None:
+            return None
+
+        id_text = str(raw_id)
+        if id_text.startswith("data_entry:"):
+            id_text = id_text.removeprefix("data_entry:")
+
+        return UUID(id_text)
+
+    def _artifacts_from_fetch_response(
+        self,
+        fetched: RawFetchResponse | Path | list[Path] | None,
+        source_item: dict[str, Any],
+        storage_id: UUID,
+        used_filenames: set[str],
+    ) -> list[ResearchArtifact]:
+        """Convert an Edison data-storage fetch result into research artifacts."""
+        if fetched is None:
+            return []
+
+        if isinstance(fetched, RawFetchResponse):
+            filename = self._artifact_filename(
+                fetched.filename or source_item.get("file_path") or fetched.entry_name,
+                used_filenames,
+            )
+            content = fetched.content.encode("utf-8")
+            return [
+                self._make_artifact(
+                    filename=filename,
+                    content=content,
+                    source_item=source_item,
+                    storage_id=storage_id,
+                )
+            ]
+
+        if isinstance(fetched, list):
+            artifacts: list[ResearchArtifact] = []
+            for path in fetched:
+                artifacts.extend(
+                    self._artifacts_from_path(path, source_item, storage_id, used_filenames)
+                )
+            return artifacts
+
+        return self._artifacts_from_path(fetched, source_item, storage_id, used_filenames)
+
+    def _artifacts_from_path(
+        self,
+        path: Path,
+        source_item: dict[str, Any],
+        storage_id: UUID,
+        used_filenames: set[str],
+    ) -> list[ResearchArtifact]:
+        """Convert a downloaded file or directory into research artifacts."""
+        if path.is_dir():
+            artifacts: list[ResearchArtifact] = []
+            for file_path in sorted(item for item in path.rglob("*") if item.is_file()):
+                relative_name = file_path.relative_to(path).as_posix()
+                filename = self._artifact_filename(relative_name, used_filenames)
+                artifacts.append(
+                    self._make_artifact(
+                        filename=filename,
+                        content=file_path.read_bytes(),
+                        source_item=source_item,
+                        storage_id=storage_id,
+                    )
+                )
+            return artifacts
+
+        filename = self._artifact_filename(path.name, used_filenames)
+        return [
+            self._make_artifact(
+                filename=filename,
+                content=path.read_bytes(),
+                source_item=source_item,
+                storage_id=storage_id,
+            )
+        ]
+
+    def _artifact_filename(self, raw_name: Any, used_filenames: set[str]) -> str:
+        """Return a stable, unique filename for a fetched artifact."""
+        filename = Path(str(raw_name or "artifact")).name
+        if not filename or filename in {".", ".."}:
+            filename = "artifact"
+
+        candidate = filename
+        suffix = Path(filename).suffix
+        stem = Path(filename).stem or "artifact"
+        counter = 2
+        while candidate in used_filenames:
+            candidate = f"{stem}-{counter}{suffix}"
+            counter += 1
+
+        used_filenames.add(candidate)
+        return candidate
+
+    def _make_artifact(
+        self,
+        filename: str,
+        content: bytes,
+        source_item: dict[str, Any],
+        storage_id: UUID,
+    ) -> ResearchArtifact:
+        """Build a ResearchArtifact from fetched bytes."""
+        media_type = mimetypes.guess_type(filename)[0]
+        return ResearchArtifact(
+            filename=filename,
+            content_base64=base64.b64encode(content).decode("ascii"),
+            media_type=media_type,
+            source="edison_output_data",
+            data_storage_id=str(storage_id),
+            description=source_item.get("name") or source_item.get("description"),
+        )

--- a/src/deep_research_client/providers/falcon.py
+++ b/src/deep_research_client/providers/falcon.py
@@ -14,7 +14,12 @@ from edison_client.models.app import PQATaskResponse, TaskResponseVerbose
 from edison_client.models.data_storage_methods import RawFetchResponse
 
 from . import ResearchProvider
-from ..models import ResearchArtifact, ResearchResult, ProviderConfig
+from ..models import (
+    ProviderConfig,
+    ResearchArtifact,
+    ResearchResult,
+    sanitize_artifact_filename,
+)
 from ..provider_params import FalconParams
 from ..model_cards import ProviderModelCards, create_falcon_model_cards
 from ..system_prompts import DEFAULT_RESEARCH_SYSTEM_PROMPT
@@ -394,7 +399,7 @@ class FalconProvider(ResearchProvider):
 
     def _artifact_filename(self, raw_name: Any, used_filenames: set[str]) -> str:
         """Return a stable, unique filename for a fetched artifact."""
-        filename = Path(str(raw_name or "artifact")).name
+        filename = sanitize_artifact_filename(str(raw_name or "artifact"))
         if not filename or filename in {".", ".."}:
             filename = "artifact"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -174,9 +174,33 @@ def test_write_result_artifacts_sanitizes_path_traversal_names(tmp_path):
 
     _write_result_artifacts(result, output_path)
 
-    assert result.artifacts[0].path == "report_artifacts/passwd"
-    assert (tmp_path / "report_artifacts" / "passwd").read_bytes() == b"safe"
+    artifact_path = tmp_path / result.artifacts[0].path
+    assert result.artifacts[0].path.startswith("report_artifacts/")
+    assert ".." not in result.artifacts[0].path
+    assert artifact_path.read_bytes() == b"safe"
     assert not (tmp_path / "etc").exists()
+
+
+def test_write_result_artifacts_sanitizes_windows_path_traversal_names(tmp_path):
+    """Windows-style separators should not escape the sidecar artifact directory."""
+    result = ResearchResult(
+        markdown="Report",
+        provider="falcon",
+        query="query",
+        artifacts=[
+            ResearchArtifact(
+                filename=r"..\..\evil.png",
+                content_base64="c2FmZQ==",
+            )
+        ],
+    )
+
+    _write_result_artifacts(result, tmp_path / "report.md")
+
+    artifact_path = tmp_path / result.artifacts[0].path
+    assert result.artifacts[0].path == "report_artifacts/_evil.png"
+    assert artifact_path.read_bytes() == b"safe"
+    assert not (tmp_path / "evil.png").exists()
 
 
 def test_write_result_artifacts_handles_unicode_filenames(tmp_path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 """Tests for CLI behaviors."""
 
+import base64
 import os
 from pathlib import Path
 from unittest.mock import patch
@@ -130,6 +131,123 @@ def test_write_result_artifacts_sets_relative_paths(tmp_path):
     artifact_path = tmp_path / "report_artifacts" / "figure.png"
     assert artifact_path.read_bytes() == b"fake-image"
     assert result.artifacts[0].path == "report_artifacts/figure.png"
+
+
+def test_write_result_artifacts_handles_filename_collisions(tmp_path):
+    """Artifacts with duplicate filenames should be preserved with unique paths."""
+    result = ResearchResult(
+        markdown="Report",
+        provider="falcon",
+        query="query",
+        artifacts=[
+            ResearchArtifact(filename="figure.png", content_base64="Zmlyc3Q="),
+            ResearchArtifact(filename="figure.png", content_base64="c2Vjb25k"),
+        ],
+    )
+    output_path = tmp_path / "report.md"
+
+    _write_result_artifacts(result, output_path)
+
+    artifact_dir = tmp_path / "report_artifacts"
+    assert (artifact_dir / "figure.png").read_bytes() == b"first"
+    assert (artifact_dir / "figure-2.png").read_bytes() == b"second"
+    assert [artifact.path for artifact in result.artifacts] == [
+        "report_artifacts/figure.png",
+        "report_artifacts/figure-2.png",
+    ]
+
+
+def test_write_result_artifacts_sanitizes_path_traversal_names(tmp_path):
+    """Artifact filenames should not escape the sidecar artifact directory."""
+    result = ResearchResult(
+        markdown="Report",
+        provider="falcon",
+        query="query",
+        artifacts=[
+            ResearchArtifact(
+                filename="../../../etc/passwd",
+                content_base64="c2FmZQ==",
+            )
+        ],
+    )
+    output_path = tmp_path / "report.md"
+
+    _write_result_artifacts(result, output_path)
+
+    assert result.artifacts[0].path == "report_artifacts/passwd"
+    assert (tmp_path / "report_artifacts" / "passwd").read_bytes() == b"safe"
+    assert not (tmp_path / "etc").exists()
+
+
+def test_write_result_artifacts_handles_unicode_filenames(tmp_path):
+    """Unicode artifact names should be written and linked correctly."""
+    result = ResearchResult(
+        markdown="Report",
+        provider="falcon",
+        query="query",
+        artifacts=[
+            ResearchArtifact(
+                filename="figuré-α.png",
+                content_base64="aW1hZ2U=",
+            )
+        ],
+    )
+    output_path = tmp_path / "report.md"
+
+    _write_result_artifacts(result, output_path)
+
+    assert result.artifacts[0].path == "report_artifacts/figuré-α.png"
+    assert (tmp_path / "report_artifacts" / "figuré-α.png").read_bytes() == b"image"
+
+
+def test_write_result_artifacts_handles_large_artifact(tmp_path):
+    """Large artifacts should be decoded and written without truncation."""
+    payload = b"x" * (1024 * 1024)
+    result = ResearchResult(
+        markdown="Report",
+        provider="falcon",
+        query="query",
+        artifacts=[
+            ResearchArtifact(
+                filename="large.bin",
+                content_base64=base64.b64encode(payload).decode("ascii"),
+            )
+        ],
+    )
+
+    _write_result_artifacts(result, tmp_path / "report.md")
+
+    assert (tmp_path / "report_artifacts" / "large.bin").read_bytes() == payload
+
+
+def test_write_result_artifacts_rejects_invalid_base64(tmp_path):
+    """Corrupted artifact payloads should fail with a clear error."""
+    result = ResearchResult(
+        markdown="Report",
+        provider="falcon",
+        query="query",
+        artifacts=[
+            ResearchArtifact(filename="broken.png", content_base64="not valid base64!")
+        ],
+    )
+
+    with pytest.raises(ValueError, match="Invalid base64 content for artifact broken.png"):
+        _write_result_artifacts(result, tmp_path / "report.md")
+
+
+def test_write_result_artifacts_surfaces_directory_creation_failure(tmp_path):
+    """Filesystem errors while creating artifact directories should not be swallowed."""
+    blocked_parent = tmp_path / "blocked"
+    blocked_parent.write_text("not a directory", encoding="utf-8")
+    result = ResearchResult(
+        markdown="Report",
+        provider="falcon",
+        query="query",
+        artifacts=[ResearchArtifact(filename="figure.png", content_base64="ZGF0YQ==")],
+    )
+
+    with pytest.raises(OSError):
+        _write_result_artifacts(result, blocked_parent / "report.md")
 
 
 def test_collect_noop_research_option_warnings_for_asta():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,8 +11,9 @@ from deep_research_client.cli import (
     app,
     _collect_noop_research_option_warnings,
     _effective_research_options,
+    _write_result_artifacts,
 )
-from deep_research_client.models import CacheConfig
+from deep_research_client.models import CacheConfig, ResearchArtifact, ResearchResult
 
 
 runner = CliRunner()
@@ -106,6 +107,29 @@ def test_research_help_lists_openscientist_provider():
 
     assert result.exit_code == 0, result.output
     assert "openscientist" in result.stdout
+
+
+def test_write_result_artifacts_sets_relative_paths(tmp_path):
+    """CLI artifact writer should materialize sidecar files for markdown links."""
+    result = ResearchResult(
+        markdown="Report",
+        provider="falcon",
+        query="query",
+        artifacts=[
+            ResearchArtifact(
+                filename="figure.png",
+                content_base64="ZmFrZS1pbWFnZQ==",
+                media_type="image/png",
+            )
+        ],
+    )
+    output_path = tmp_path / "report.md"
+
+    _write_result_artifacts(result, output_path)
+
+    artifact_path = tmp_path / "report_artifacts" / "figure.png"
+    assert artifact_path.read_bytes() == b"fake-image"
+    assert result.artifacts[0].path == "report_artifacts/figure.png"
 
 
 def test_collect_noop_research_option_warnings_for_asta():

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,6 +12,7 @@ import pytest
 from deep_research_client import DeepResearchClient, ResearchResult, ProviderConfig, CacheConfig
 from deep_research_client.providers import ResearchProvider
 from deep_research_client.providers.asta import AstaProvider
+from deep_research_client.providers.falcon import FalconProvider
 
 
 class MockProvider(ResearchProvider):
@@ -166,6 +167,19 @@ def test_asta_cache_params_include_version_tag():
         "paper_limit": 20,
         "_cache_version": "snippet-v5",
     }
+
+
+def test_falcon_cache_params_include_artifact_version_tag():
+    """Falcon cache keys should invalidate stale no-artifact Edison entries."""
+    cache_config = CacheConfig(enabled=False)
+    with patch.dict(os.environ, {}, clear=True):
+        client = DeepResearchClient(cache_config=cache_config)
+
+    provider = FalconProvider(ProviderConfig(
+        name="falcon", api_key="edison-key", enabled=True))
+    cache_params = client._get_cache_provider_params(provider)
+
+    assert cache_params == {"_cache_version": "artifacts-v1"}
 
 
 async def test_research_with_mock_provider():

--- a/tests/test_falcon_provider.py
+++ b/tests/test_falcon_provider.py
@@ -232,6 +232,34 @@ def test_extract_output_data_from_environment_frame():
     ]
 
 
+def test_extract_answer_artifacts_from_verbose_response():
+    """Edison Literature answer artifacts should become durable artifacts."""
+    config = ProviderConfig(name="falcon", api_key="test-key")
+    provider = FalconProvider(config)
+    response = create_verbose_response(
+        {
+            "state": {
+                "state": {
+                    "response": {
+                        "answer": {
+                            "formatted_answer": "Formatted answer",
+                            "artifacts": {"artifact-00": "| A | B |\n| - | - |"},
+                        }
+                    }
+                }
+            }
+        }
+    )
+
+    artifacts = provider._extract_answer_artifacts(response)
+
+    assert len(artifacts) == 1
+    artifact = artifacts[0]
+    assert artifact.filename == "artifact-00.md"
+    assert artifact.media_type == "text/markdown"
+    assert artifact.source == "edison_answer_artifacts"
+
+
 def test_artifacts_from_raw_fetch_response():
     """Raw Edison storage content should become a durable research artifact."""
     from edison_client.models.data_storage_methods import RawFetchResponse

--- a/tests/test_falcon_provider.py
+++ b/tests/test_falcon_provider.py
@@ -313,8 +313,12 @@ def test_artifact_filename_handles_collisions_and_path_traversal():
     provider = FalconProvider(config)
     used_filenames: set[str] = set()
 
-    assert provider._artifact_filename("../../../etc/passwd", used_filenames) == "passwd"
-    assert provider._artifact_filename("passwd", used_filenames) == "passwd-2"
+    first_name = provider._artifact_filename("../../../etc/passwd", used_filenames)
+    assert ".." not in first_name
+    assert "/" not in first_name
+    assert "\\" not in first_name
+    assert provider._artifact_filename(first_name, used_filenames) == f"{first_name}-2"
+    assert provider._artifact_filename(r"..\..\evil.png", used_filenames) == "_evil.png"
     assert provider._artifact_filename("", used_filenames) == "artifact"
 
 
@@ -410,7 +414,7 @@ def test_artifacts_from_directory_fetch_response(tmp_path):
         used_filenames=set(),
     )
 
-    assert [artifact.filename for artifact in artifacts] == ["figure.svg", "summary.md"]
+    assert [artifact.filename for artifact in artifacts] == ["nested_figure.svg", "summary.md"]
     assert [artifact.media_type for artifact in artifacts] == ["image/svg+xml", "text/markdown"]
 
 

--- a/tests/test_falcon_provider.py
+++ b/tests/test_falcon_provider.py
@@ -2,6 +2,8 @@
 
 import pytest
 from datetime import datetime
+from pathlib import Path
+from uuid import UUID
 
 # Skip all tests in this module if edison_client is not installed
 pytest.importorskip("edison_client")
@@ -40,6 +42,30 @@ def create_mock_pqa_response(
     )
 
 
+def create_verbose_response(environment_frame: dict):
+    """Create a verbose Edison response for testing."""
+    from edison_client.models.app import TaskResponseVerbose
+
+    return TaskResponseVerbose.model_construct(
+        status="completed",
+        query="test query",
+        user=None,
+        created_at=datetime.now(),
+        job_name="literature-20260216",
+        share_status="private",
+        permitted_accessors=None,
+        build_owner=None,
+        environment_name=None,
+        agent_name=None,
+        task_id=None,
+        project_id=None,
+        agent_state=None,
+        environment_frame=environment_frame,
+        metadata=None,
+        deployment_config=None,
+    )
+
+
 def test_extract_text_from_pqa_response():
     """Test extracting text content from PQATaskResponse."""
     config = ProviderConfig(name="falcon", api_key="test-key")
@@ -53,6 +79,33 @@ def test_extract_text_from_pqa_response():
 
     text = provider._extract_text_content(response)
     assert text == "Formatted answer with (smith2020study pages 1-5) citations"
+
+
+def test_extract_text_from_verbose_response():
+    """Verbose Edison responses should read formatted answers from the frame."""
+    config = ProviderConfig(name="falcon", api_key="test-key")
+    provider = FalconProvider(config)
+
+    response = [
+        create_verbose_response(
+            {
+                "state": {
+                    "state": {
+                        "response": {
+                            "answer": {
+                                "answer": "Plain answer",
+                                "formatted_answer": "Formatted answer",
+                            }
+                        }
+                    }
+                }
+            }
+        )
+    ]
+
+    text = provider._extract_text_content(response)
+
+    assert text == "Formatted answer"
 
 
 def test_extract_text_fallback_to_answer():
@@ -155,3 +208,54 @@ def test_extract_no_citations():
     citations = provider._extract_citations(response, report_text)
 
     assert citations == []
+
+
+def test_extract_output_data_from_environment_frame():
+    """Output data entries should be found in the final Edison frame."""
+    config = ProviderConfig(name="falcon", api_key="test-key")
+    provider = FalconProvider(config)
+
+    environment_frame = {
+        "state": {
+            "info": {
+                "output_data": [
+                    {"entry_id": "data_entry:11111111-1111-1111-1111-111111111111"}
+                ]
+            }
+        }
+    }
+
+    output_data = provider._extract_output_data(environment_frame)
+
+    assert output_data == [
+        {"entry_id": "data_entry:11111111-1111-1111-1111-111111111111"}
+    ]
+
+
+def test_artifacts_from_raw_fetch_response():
+    """Raw Edison storage content should become a durable research artifact."""
+    from edison_client.models.data_storage_methods import RawFetchResponse
+
+    config = ProviderConfig(name="falcon", api_key="test-key")
+    provider = FalconProvider(config)
+    storage_id = UUID("11111111-1111-1111-1111-111111111111")
+
+    artifacts = provider._artifacts_from_fetch_response(
+        RawFetchResponse(
+            filename=Path("figure.svg"),
+            content="<svg></svg>",
+            entry_id=storage_id,
+            entry_name="Figure 1",
+        ),
+        source_item={"name": "Figure 1"},
+        storage_id=storage_id,
+        used_filenames=set(),
+    )
+
+    assert len(artifacts) == 1
+    artifact = artifacts[0]
+    assert artifact.filename == "figure.svg"
+    assert artifact.media_type == "image/svg+xml"
+    assert artifact.is_image is True
+    assert artifact.description == "Figure 1"
+    assert artifact.data_storage_id == str(storage_id)

--- a/tests/test_falcon_provider.py
+++ b/tests/test_falcon_provider.py
@@ -232,6 +232,53 @@ def test_extract_output_data_from_environment_frame():
     ]
 
 
+def test_extract_output_data_from_complex_nested_environment_frame():
+    """Output data entries should be found in non-standard nested frame shapes."""
+    config = ProviderConfig(name="falcon", api_key="test-key")
+    provider = FalconProvider(config)
+
+    environment_frame = {
+        "state": {"info": {"not_output_data": []}},
+        "supplemental_data": [
+            {"nested": {"output_data": [{"entry_id": "22222222-2222-2222-2222-222222222222"}]}},
+            {"output_data": ["not-a-dict", {"data_storage_id": "33333333-3333-3333-3333-333333333333"}]},
+        ],
+    }
+
+    output_data = provider._extract_output_data(environment_frame)
+
+    assert output_data == [
+        {"entry_id": "22222222-2222-2222-2222-222222222222"},
+        {"data_storage_id": "33333333-3333-3333-3333-333333333333"},
+    ]
+
+
+@pytest.mark.parametrize(
+    ("item", "expected"),
+    [
+        (
+            {"entry_id": "data_entry:11111111-1111-1111-1111-111111111111"},
+            UUID("11111111-1111-1111-1111-111111111111"),
+        ),
+        (
+            {"data_storage_id": "22222222-2222-2222-2222-222222222222"},
+            UUID("22222222-2222-2222-2222-222222222222"),
+        ),
+        (
+            {"id": UUID("33333333-3333-3333-3333-333333333333")},
+            UUID("33333333-3333-3333-3333-333333333333"),
+        ),
+        ({}, None),
+    ],
+)
+def test_get_data_storage_id_accepts_supported_id_shapes(item, expected):
+    """Edison output entries can identify storage records with several keys."""
+    config = ProviderConfig(name="falcon", api_key="test-key")
+    provider = FalconProvider(config)
+
+    assert provider._get_data_storage_id(item) == expected
+
+
 def test_extract_answer_artifacts_from_verbose_response():
     """Edison Literature answer artifacts should become durable artifacts."""
     config = ProviderConfig(name="falcon", api_key="test-key")
@@ -258,6 +305,17 @@ def test_extract_answer_artifacts_from_verbose_response():
     assert artifact.filename == "artifact-00.md"
     assert artifact.media_type == "text/markdown"
     assert artifact.source == "edison_answer_artifacts"
+
+
+def test_artifact_filename_handles_collisions_and_path_traversal():
+    """Provider artifact filenames should be basename-only and unique."""
+    config = ProviderConfig(name="falcon", api_key="test-key")
+    provider = FalconProvider(config)
+    used_filenames: set[str] = set()
+
+    assert provider._artifact_filename("../../../etc/passwd", used_filenames) == "passwd"
+    assert provider._artifact_filename("passwd", used_filenames) == "passwd-2"
+    assert provider._artifact_filename("", used_filenames) == "artifact"
 
 
 def test_artifacts_from_raw_fetch_response():
@@ -287,3 +345,120 @@ def test_artifacts_from_raw_fetch_response():
     assert artifact.is_image is True
     assert artifact.description == "Figure 1"
     assert artifact.data_storage_id == str(storage_id)
+
+
+def test_artifacts_from_path_fetch_response(tmp_path):
+    """Downloaded Edison files should become artifacts."""
+    config = ProviderConfig(name="falcon", api_key="test-key")
+    provider = FalconProvider(config)
+    storage_id = UUID("11111111-1111-1111-1111-111111111111")
+    image_path = tmp_path / "plot.png"
+    image_path.write_bytes(b"png bytes")
+
+    artifacts = provider._artifacts_from_fetch_response(
+        image_path,
+        source_item={"description": "Generated plot"},
+        storage_id=storage_id,
+        used_filenames=set(),
+    )
+
+    assert len(artifacts) == 1
+    artifact = artifacts[0]
+    assert artifact.filename == "plot.png"
+    assert artifact.media_type == "image/png"
+    assert artifact.description == "Generated plot"
+    assert artifact.data_storage_id == str(storage_id)
+
+
+def test_artifacts_from_list_fetch_response_handles_collisions(tmp_path):
+    """Multiple downloaded paths with same names should all be preserved."""
+    first_dir = tmp_path / "first"
+    second_dir = tmp_path / "second"
+    first_dir.mkdir()
+    second_dir.mkdir()
+    first_plot = first_dir / "plot.png"
+    second_plot = second_dir / "plot.png"
+    first_plot.write_bytes(b"first")
+    second_plot.write_bytes(b"second")
+    config = ProviderConfig(name="falcon", api_key="test-key")
+    provider = FalconProvider(config)
+
+    artifacts = provider._artifacts_from_fetch_response(
+        [first_plot, second_plot],
+        source_item={},
+        storage_id=UUID("11111111-1111-1111-1111-111111111111"),
+        used_filenames=set(),
+    )
+
+    assert [artifact.filename for artifact in artifacts] == ["plot.png", "plot-2.png"]
+
+
+def test_artifacts_from_directory_fetch_response(tmp_path):
+    """Directory downloads should recursively produce one artifact per file."""
+    output_dir = tmp_path / "downloaded"
+    nested_dir = output_dir / "nested"
+    nested_dir.mkdir(parents=True)
+    (output_dir / "summary.md").write_text("# Summary", encoding="utf-8")
+    (nested_dir / "figure.svg").write_text("<svg></svg>", encoding="utf-8")
+    config = ProviderConfig(name="falcon", api_key="test-key")
+    provider = FalconProvider(config)
+
+    artifacts = provider._artifacts_from_fetch_response(
+        output_dir,
+        source_item={"name": "Directory output"},
+        storage_id=UUID("11111111-1111-1111-1111-111111111111"),
+        used_filenames=set(),
+    )
+
+    assert [artifact.filename for artifact in artifacts] == ["figure.svg", "summary.md"]
+    assert [artifact.media_type for artifact in artifacts] == ["image/svg+xml", "text/markdown"]
+
+
+def test_extract_artifacts_combines_answer_and_output_data_artifacts(tmp_path):
+    """Full extraction should include direct answer artifacts and fetched output_data."""
+
+    class FakeEdisonClient:
+        def __init__(self, fetched_path: Path):
+            self.fetched_path = fetched_path
+            self.fetch_calls: list[UUID] = []
+
+        def fetch_data_from_storage(self, data_storage_id: UUID):
+            self.fetch_calls.append(data_storage_id)
+            return self.fetched_path
+
+    fetched_path = tmp_path / "artifact-00.md"
+    fetched_path.write_text("Fetched artifact", encoding="utf-8")
+    storage_id = UUID("11111111-1111-1111-1111-111111111111")
+    response = [
+        create_verbose_response(
+            {
+                "state": {
+                    "info": {
+                        "output_data": [
+                            {"entry_id": f"data_entry:{storage_id}"},
+                            {"entry_id": f"data_entry:{storage_id}"},
+                        ]
+                    },
+                    "state": {
+                        "response": {
+                            "answer": {
+                                "formatted_answer": "Formatted answer",
+                                "artifacts": {"artifact-00": "Answer artifact"},
+                            }
+                        }
+                    },
+                }
+            }
+        )
+    ]
+    config = ProviderConfig(name="falcon", api_key="test-key")
+    provider = FalconProvider(config)
+    client = FakeEdisonClient(fetched_path)
+
+    artifacts = provider._extract_artifacts(client, response)
+
+    assert [artifact.filename for artifact in artifacts] == [
+        "artifact-00.md",
+        "artifact-00-2.md",
+    ]
+    assert client.fetch_calls == [storage_id]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,14 +2,16 @@
 
 import pytest
 from pydantic import ValidationError
+import yaml
 
+from deep_research_client.formatter import ResultFormatter as LegacyResultFormatter
 from deep_research_client.models import (
     CacheConfig,
     ProviderConfig,
     ResearchArtifact,
     ResearchResult,
 )
-from deep_research_client.processing import ResearchProcessor
+from deep_research_client.processing import ResearchProcessor, ResultFormatter
 
 
 def test_research_result_creation():
@@ -175,3 +177,82 @@ def test_format_research_result_includes_image_artifacts():
     assert "artifact_count: 1" in formatted
     assert "## Artifacts" in formatted
     assert "![Figure 1](report_artifacts/figure.png)" in formatted
+
+
+@pytest.mark.parametrize("formatter_class", [ResultFormatter, LegacyResultFormatter])
+def test_format_research_result_includes_artifact_frontmatter(formatter_class):
+    """Formatter frontmatter should preserve structured artifact metadata."""
+    result = ResearchResult(
+        markdown="# Report",
+        provider="falcon",
+        query="query",
+        artifacts=[
+            ResearchArtifact(
+                filename="figure.png",
+                content_base64="ZmFrZQ==",
+                media_type="image/png",
+                path="report_artifacts/figure.png",
+                source="edison_output_data",
+                data_storage_id="11111111-1111-1111-1111-111111111111",
+                description="Figure 1",
+            )
+        ],
+    )
+
+    formatted = formatter_class().format_full_markdown(result)
+    frontmatter = yaml.safe_load(formatted.split("---", 2)[1])
+
+    assert frontmatter["artifact_count"] == 1
+    assert frontmatter["artifacts"] == [
+        {
+            "filename": "figure.png",
+            "path": "report_artifacts/figure.png",
+            "media_type": "image/png",
+            "source": "edison_output_data",
+            "data_storage_id": "11111111-1111-1111-1111-111111111111",
+            "description": "Figure 1",
+        }
+    ]
+
+
+@pytest.mark.parametrize("formatter_class", [ResultFormatter, LegacyResultFormatter])
+def test_format_research_result_handles_mixed_artifacts(formatter_class):
+    """Formatters should embed images, link files, and preserve artifact order."""
+    long_description = "Supplementary table " + "with detailed evidence " * 20
+    result = ResearchResult(
+        markdown="# Report",
+        provider="falcon",
+        query="query",
+        artifacts=[
+            ResearchArtifact(
+                filename="figure.png",
+                content_base64="ZmFrZQ==",
+                media_type="image/png",
+                path="report_artifacts/figure.png",
+                description="Figure 1",
+            ),
+            ResearchArtifact(
+                filename="supplement.md",
+                content_base64="ZmFrZQ==",
+                media_type="text/markdown",
+                path="report_artifacts/supplement.md",
+                description=long_description,
+            ),
+            ResearchArtifact(
+                filename="raw.json",
+                content_base64="e30=",
+                media_type="application/json",
+            ),
+        ],
+    )
+
+    formatted = formatter_class().format_full_markdown(result)
+
+    image_line = "![Figure 1](report_artifacts/figure.png)"
+    supplement_line = f"- [{long_description}](report_artifacts/supplement.md)"
+    fallback_line = "- [raw.json](raw.json)"
+    assert image_line in formatted
+    assert supplement_line in formatted
+    assert fallback_line in formatted
+    assert formatted.index(image_line) < formatted.index(supplement_line)
+    assert formatted.index(supplement_line) < formatted.index(fallback_line)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,7 +3,13 @@
 import pytest
 from pydantic import ValidationError
 
-from deep_research_client.models import ResearchResult, ProviderConfig, CacheConfig
+from deep_research_client.models import (
+    CacheConfig,
+    ProviderConfig,
+    ResearchArtifact,
+    ResearchResult,
+)
+from deep_research_client.processing import ResearchProcessor
 
 
 def test_research_result_creation():
@@ -31,6 +37,7 @@ def test_research_result_with_defaults():
     )
 
     assert result.citations == []  # Default empty list
+    assert result.artifacts == []  # Default empty list
     assert result.cached is False
 
 
@@ -133,3 +140,38 @@ def test_model_deserialization():
     result = ResearchResult(**data)
     assert result.markdown == "# Test Result"
     assert result.cached is True
+
+
+def test_research_artifact_image_detection():
+    """Research artifacts should identify embeddable image media types."""
+    artifact = ResearchArtifact(
+        filename="figure.png",
+        content_base64="ZmFrZQ==",
+        media_type="image/png",
+    )
+
+    assert artifact.is_image is True
+
+
+def test_format_research_result_includes_image_artifacts():
+    """Formatted markdown should embed image artifacts."""
+    result = ResearchResult(
+        markdown="# Report",
+        provider="falcon",
+        query="query",
+        artifacts=[
+            ResearchArtifact(
+                filename="figure.png",
+                content_base64="ZmFrZQ==",
+                media_type="image/png",
+                path="report_artifacts/figure.png",
+                description="Figure 1",
+            )
+        ],
+    )
+
+    formatted = ResearchProcessor().format_research_result(result)
+
+    assert "artifact_count: 1" in formatted
+    assert "## Artifacts" in formatted
+    assert "![Figure 1](report_artifacts/figure.png)" in formatted

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,6 +4,7 @@ import pytest
 from pydantic import ValidationError
 import yaml
 
+import deep_research_client.models as model_module
 from deep_research_client.formatter import ResultFormatter as LegacyResultFormatter
 from deep_research_client.models import (
     CacheConfig,
@@ -153,6 +154,27 @@ def test_research_artifact_image_detection():
     )
 
     assert artifact.is_image is True
+
+
+def test_research_artifact_sanitizes_filename():
+    """Artifact filenames should be sanitized at model construction time."""
+    artifact = ResearchArtifact(
+        filename=r"..\..\figure.png",
+        content_base64="ZmFrZQ==",
+    )
+
+    assert artifact.filename == "_figure.png"
+
+
+def test_research_artifact_rejects_oversized_content(monkeypatch):
+    """Artifact model validation should reject payloads above the size limit."""
+    monkeypatch.setattr(model_module, "MAX_ARTIFACT_BYTES", 10)
+
+    with pytest.raises(ValueError, match="Artifact too large"):
+        ResearchArtifact(
+            filename="large.bin",
+            content_base64="A" * 16,
+        )
 
 
 def test_format_research_result_includes_image_artifacts():


### PR DESCRIPTION
## Summary
- request verbose Edison task responses and fetch `output_data` artifacts from the final environment frame
- store artifacts on `ResearchResult`, write sidecar files for saved reports, and embed image artifacts in Markdown
- document Edison artifact behavior and invalidate stale Falcon cache entries

Closes #40

## Validation
- `just test`
- `uv run mkdocs build --strict` currently stops on an existing broken link in `docs/explanation/ralph-wiggum-deep-research.md` to `../workflows/deep-research.yaml`