### PR TITLE
Follow-ups for retrieving images from Edison deep research

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ deep-research-client research "Explain quantum computing" --provider perplexity 
 # Save to file (citations included by default)
 deep-research-client research "Machine learning trends 2024" --output report.md
 
+# Retrieve an existing Edison trajectory by ID
+deep-research-client edison-trajectory 784d73d5-da42-402e-9701-6c5b44beab14 --output edison-report.md
+
 # Save citations to separate file
 deep-research-client research "AI trends 2024" --output report.md --separate-citations
 
@@ -902,7 +905,7 @@ deep-research-client research "simple question" --provider perplexity --model so
 | Consensus | `CONSENSUS_API_KEY` | Consensus Academic Search | Peer-reviewed academic papers, evidence-based research |
 | OpenScientist | `OPENSCIENTIST_API_KEY` | openscientist-autonomous | Iterative hypothesis-driven research, PubMed PMID citations |
 
-When Edison produces diagrams, charts, figures, or other output artifacts, saved reports include an `Artifacts` section. Image artifacts are written to a sidecar directory such as `report_artifacts/` and embedded with relative Markdown links.
+When Edison produces diagrams, charts, figures, or other output artifacts, saved reports include an `Artifacts` section. Both the standard `research` command and `edison-trajectory` materialize recovered artifacts beside the output markdown in a sidecar directory such as `report_artifacts/`, and image artifacts are embedded with relative Markdown links. Rehydrated Edison trajectories also record `trajectory_id` and `artifact_sources` in frontmatter.
 
 ## Development
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -47,6 +47,8 @@ deep-research-client research [OPTIONS] [QUERY]
 | `--author TEXT` | Primary author of the research |
 | `--contributor TEXT` | Contributor to the research (repeatable) |
 
+When `--output` is provided, any non-text artifacts recovered with the report are written beside it in an `OUTPUT_STEM_artifacts/` directory and linked from the generated markdown.
+
 #### Examples
 
 ```bash
@@ -97,6 +99,48 @@ deep-research-client research "CFAP300 gene function" \
 deep-research-client research "AI" \
   --base-url https://api.example.com \
   --api-key-env CUSTOM_API_KEY
+```
+
+---
+
+### edison-trajectory
+
+Retrieve an existing Edison trajectory by ID, preserving any report artifacts recovered from the verbose trajectory payload.
+
+```bash
+deep-research-client edison-trajectory [OPTIONS] TRAJECTORY_ID
+```
+
+#### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `TRAJECTORY_ID` | Existing Edison trajectory/task ID |
+
+#### Options
+
+| Option | Description |
+|--------|-------------|
+| `--output PATH` | Output file path (prints to stdout if not provided) |
+| `--separate-citations PATH` | Save citations to a separate file |
+
+#### Notes
+
+- Requires `EDISON_API_KEY` (or legacy `FUTUREHOUSE_API_KEY`) to be set.
+- When `--output` is provided, recovered artifacts are written beside the report in an `OUTPUT_STEM_artifacts/` directory.
+- Frontmatter includes `trajectory_id` and `artifact_sources` so it is clear where recovered artifacts came from.
+
+#### Examples
+
+```bash
+# Retrieve an Edison trajectory into the current directory
+deep-research-client edison-trajectory 784d73d5-da42-402e-9701-6c5b44beab14 \
+  --output edison-report.md
+
+# Write citations separately
+deep-research-client edison-trajectory 784d73d5-da42-402e-9701-6c5b44beab14 \
+  --output edison-report.md \
+  --separate-citations edison-report.citations.md
 ```
 
 ---

--- a/src/deep_research_client/cli.py
+++ b/src/deep_research_client/cli.py
@@ -571,6 +571,71 @@ def research(
 
 
 @app.command()
+def edison_trajectory(
+    trajectory_id: Annotated[str, typer.Argument(help="Existing Edison trajectory/task ID")],
+    output: Annotated[Optional[Path], typer.Option(
+        help="Output file path (prints to stdout if not provided)")] = None,
+    separate_citations: Annotated[Optional[Path], typer.Option(
+        "--separate-citations", help="Save citations to separate file (optional path, defaults to output.citations.md)")] = None,
+):
+    """Retrieve an existing Edison trajectory report and artifacts by ID."""
+    from .models import ProviderConfig
+    from .providers.falcon import FalconProvider
+
+    api_key = os.getenv("EDISON_API_KEY") or os.getenv("FUTUREHOUSE_API_KEY")
+    if not api_key:
+        logger.error("EDISON_API_KEY is required to retrieve an Edison trajectory")
+        raise typer.Exit(1)
+
+    processor = ResearchProcessor()
+    provider = FalconProvider(ProviderConfig(name="falcon", api_key=api_key, enabled=True))
+
+    try:
+        result = provider.retrieve_trajectory(trajectory_id)
+        should_separate_citations = separate_citations is not None
+
+        if output:
+            _write_result_artifacts(result, output)
+
+        output_content = processor.format_research_result(
+            result,
+            separate_citations=should_separate_citations,
+        )
+
+        if output:
+            output.write_text(output_content, encoding="utf-8")
+            logger.info(f"Result saved to: {output}")
+
+            if should_separate_citations and result.citations:
+                if isinstance(separate_citations, Path):
+                    citations_output = separate_citations
+                else:
+                    citations_output = output.with_suffix('.citations.md')
+
+                citations_content = processor.format_citations_only(result)
+                citations_output.write_text(citations_content, encoding="utf-8")
+                logger.info(f"Citations saved to: {citations_output}")
+
+            if result.citations:
+                logger.info(f"Found {len(result.citations)} citations")
+            if result.artifacts:
+                logger.info(f"Recovered {len(result.artifacts)} artifacts")
+        else:
+            typer.echo("\n" + "=" * 60)
+            typer.echo(output_content)
+            if should_separate_citations and result.citations:
+                typer.echo("\n" + "=" * 60)
+                typer.echo("CITATIONS:")
+                typer.echo("=" * 60)
+                typer.echo(processor.format_citations_only(result))
+
+    except Exception as e:
+        logger.error(f"Error: {e}")
+        logger.debug("Exception details:", exc_info=True)
+        raise typer.Exit(1)
+
+
+@app.command()
 def providers(
     show_params: Annotated[bool, typer.Option(
         "--show-params", help="Show available parameters for each provider")] = False,

--- a/src/deep_research_client/cli.py
+++ b/src/deep_research_client/cli.py
@@ -564,8 +564,11 @@ def research(
                 typer.echo("\n" + "="*60)
                 typer.echo(output_content)
 
-    except Exception as e:
-        logger.error(f"Error: {e}")
+    except ValueError as exc:
+        logger.error(f"Error: {exc}")
+        raise typer.Exit(1)
+    except OSError as exc:
+        logger.error(f"Filesystem error: {exc}")
         logger.debug("Exception details:", exc_info=True)
         raise typer.Exit(1)
 

--- a/src/deep_research_client/formatter.py
+++ b/src/deep_research_client/formatter.py
@@ -1,5 +1,6 @@
 """Output formatting utilities for research results."""
 
+from collections import Counter
 import yaml
 from typing import Dict, Any
 
@@ -47,6 +48,9 @@ class ResultFormatter:
         # Add provider configuration
         if result.provider_config:
             metadata["provider_config"] = result.provider_config
+            trajectory_id = result.provider_config.get("trajectory_id")
+            if trajectory_id:
+                metadata["trajectory_id"] = trajectory_id
 
         # Add citation count
         if result.citations:
@@ -54,6 +58,9 @@ class ResultFormatter:
 
         if result.artifacts:
             metadata["artifact_count"] = len(result.artifacts)
+            metadata["artifact_sources"] = dict(
+                Counter((artifact.source or "unknown") for artifact in result.artifacts)
+            )
             metadata["artifacts"] = [
                 {
                     "filename": artifact.filename,

--- a/src/deep_research_client/processing/result_formatter.py
+++ b/src/deep_research_client/processing/result_formatter.py
@@ -1,5 +1,6 @@
 """Output formatting utilities for research results."""
 
+from collections import Counter
 import yaml
 from typing import Dict, Any
 
@@ -61,6 +62,9 @@ class ResultFormatter:
         # Add provider configuration
         if result.provider_config:
             metadata["provider_config"] = result.provider_config
+            trajectory_id = result.provider_config.get("trajectory_id")
+            if trajectory_id:
+                metadata["trajectory_id"] = trajectory_id
 
         # Add citation count
         if result.citations:
@@ -68,6 +72,9 @@ class ResultFormatter:
 
         if result.artifacts:
             metadata["artifact_count"] = len(result.artifacts)
+            metadata["artifact_sources"] = dict(
+                Counter((artifact.source or "unknown") for artifact in result.artifacts)
+            )
             metadata["artifacts"] = [
                 {
                     "filename": artifact.filename,

--- a/src/deep_research_client/provider_params.py
+++ b/src/deep_research_client/provider_params.py
@@ -124,6 +124,15 @@ class FalconParams(BaseProviderParams):
         gt=0,
         description="Maximum tokens in response"
     )
+    max_embedded_images: int = Field(
+        default=8,
+        ge=0,
+        le=100,
+        description=(
+            "Maximum number of embedded Edison image artifacts to preserve from "
+            "verbose message history. Set to 0 to disable recovery of embedded images."
+        )
+    )
 
 
 class AstaParams(BaseProviderParams):

--- a/src/deep_research_client/providers/falcon.py
+++ b/src/deep_research_client/providers/falcon.py
@@ -27,6 +27,9 @@ from ..system_prompts import DEFAULT_RESEARCH_SYSTEM_PROMPT
 logger = logging.getLogger(__name__)
 
 
+_DATA_URL_PREFIX = "data:"
+
+
 class FalconProvider(ResearchProvider):
     """Provider for Edison Scientific API (formerly FutureHouse Falcon)."""
 
@@ -75,28 +78,52 @@ class FalconProvider(ResearchProvider):
             logger.debug("Making API request to Edison")
             response = client.run_tasks_until_done(task_data, verbose=True)
             logger.info("Edison API request completed successfully")
-
-            # Extract the report text and citations
-            markdown_content = self._extract_text_content(response)
-            logger.debug(f"Extracted markdown content: {len(markdown_content)} characters")
-
-            citations = self._extract_citations(response, markdown_content)
-            logger.info(f"Extracted {len(citations)} citations from response")
-
-            artifacts = self._extract_artifacts(client, response)
-            logger.info(f"Extracted {len(artifacts)} artifacts from response")
-
-            return ResearchResult(
-                markdown=markdown_content,
-                citations=citations,
-                artifacts=artifacts,
-                provider=self.name,
-                query=query
-            )
+            return self._result_from_response(client, response, query)
         except Exception as e:
             logger.error(f"Edison API request failed: {e}")
             logger.debug("Error details:", exc_info=True)
             raise
+
+    def retrieve_trajectory(self, trajectory_id: str) -> ResearchResult:
+        """Retrieve an existing Edison trajectory and preserve its artifacts."""
+        if not self.is_available():
+            raise ValueError(f"Edison provider not available (API key: {bool(self.config.api_key)})")
+
+        client = EdisonClient(api_key=self.config.api_key)
+        logger.info(f"Retrieving Edison trajectory {trajectory_id}")
+        response = [client.get_task(task_id=trajectory_id, verbose=True)]
+        query = response[0].query or f"Edison trajectory {trajectory_id}"
+        result = self._result_from_response(client, response, query)
+        result.provider_config = {
+            **(result.provider_config or {}),
+            "trajectory_id": trajectory_id,
+            "retrieval_mode": "edison_trajectory",
+        }
+        return result
+
+    def _result_from_response(
+        self,
+        client: EdisonClient,
+        response: list[Any],
+        query: str,
+    ) -> ResearchResult:
+        """Build a research result from an Edison verbose response."""
+        markdown_content = self._extract_text_content(response)
+        logger.debug(f"Extracted markdown content: {len(markdown_content)} characters")
+
+        citations = self._extract_citations(response, markdown_content)
+        logger.info(f"Extracted {len(citations)} citations from response")
+
+        artifacts = self._extract_artifacts(client, response)
+        logger.info(f"Extracted {len(artifacts)} artifacts from response")
+
+        return ResearchResult(
+            markdown=markdown_content,
+            citations=citations,
+            artifacts=artifacts,
+            provider=self.name,
+            query=query,
+        )
 
     def _extract_text_content(self, response) -> str:
         """Extract text content from Edison response.
@@ -188,7 +215,7 @@ class FalconProvider(ResearchProvider):
 
         return []
 
-    def _extract_artifacts(self, client: EdisonClient, response: list[Any]) -> list[ResearchArtifact]:
+    def _extract_artifacts(self, client: Any, response: list[Any]) -> list[ResearchArtifact]:
         """Fetch artifacts listed in the final Edison environment frame."""
         if not response:
             return []
@@ -199,6 +226,12 @@ class FalconProvider(ResearchProvider):
 
         output_data = self._extract_output_data(task_response.environment_frame or {})
         artifacts = self._extract_answer_artifacts(task_response)
+        artifacts.extend(
+            self._extract_message_image_artifacts(
+                task_response,
+                used_filenames={artifact.filename for artifact in artifacts},
+            )
+        )
         used_storage_ids: set[str] = set()
         used_filenames: set[str] = {artifact.filename for artifact in artifacts}
 
@@ -221,6 +254,114 @@ class FalconProvider(ResearchProvider):
                 artifacts.append(artifact)
 
         return artifacts
+
+    def _extract_message_image_artifacts(
+        self,
+        response: TaskResponseVerbose,
+        used_filenames: set[str],
+    ) -> list[ResearchArtifact]:
+        """Extract one representative image from each verbose Edison image message."""
+        payload = response.model_dump(mode="python")
+        artifacts: list[ResearchArtifact] = []
+        seen_urls: set[str] = set()
+
+        for image_group in self._walk_image_message_groups(payload):
+            image_url = image_group["url"]
+            if image_url in seen_urls:
+                continue
+            seen_urls.add(image_url)
+
+            artifact = self._artifact_from_data_url(
+                image_url,
+                used_filenames=used_filenames,
+                index=len(artifacts) + 1,
+                description=image_group["description"],
+            )
+            if artifact is not None:
+                artifacts.append(artifact)
+
+        return artifacts
+
+    def _walk_image_message_groups(self, value: Any) -> Iterable[dict[str, str | None]]:
+        """Yield one representative image and description per nested message content block."""
+        if isinstance(value, dict):
+            content = value.get("content")
+            if isinstance(content, list):
+                image_urls = [
+                    item.get("image_url", {}).get("url")
+                    for item in content
+                    if isinstance(item, dict)
+                    and isinstance(item.get("image_url"), dict)
+                    and isinstance(item["image_url"].get("url"), str)
+                    and item["image_url"]["url"].startswith(f"{_DATA_URL_PREFIX}image/")
+                ]
+                if image_urls:
+                    yield {
+                        "url": image_urls[0],
+                        "description": self._image_description_from_content(content),
+                    }
+
+            for nested_value in value.values():
+                yield from self._walk_image_message_groups(nested_value)
+            return
+
+        if isinstance(value, list):
+            for nested_value in value:
+                yield from self._walk_image_message_groups(nested_value)
+
+    def _image_description_from_content(self, content: list[Any]) -> str | None:
+        """Build a concise artifact description from Edison message text content."""
+        text_items = [
+            item.get("text", "").strip()
+            for item in content
+            if isinstance(item, dict) and isinstance(item.get("text"), str)
+        ]
+        for text in text_items:
+            if not text or text.startswith("Retrieved "):
+                continue
+            condensed = " ".join(text.split())
+            return condensed[:160]
+        return None
+
+    def _artifact_from_data_url(
+        self,
+        data_url: str,
+        used_filenames: set[str],
+        index: int,
+        description: str | None = None,
+    ) -> ResearchArtifact | None:
+        """Convert a base64 data URL into a research artifact."""
+        if not data_url.startswith(_DATA_URL_PREFIX) or ";base64," not in data_url:
+            return None
+
+        header, payload = data_url[len(_DATA_URL_PREFIX):].split(",", 1)
+        if not header.endswith(";base64"):
+            return None
+
+        media_type = header.removesuffix(";base64") or None
+        if not media_type or not media_type.startswith("image/"):
+            return None
+
+        filename = self._artifact_filename(
+            f"image-{index}{self._artifact_extension_for_media_type(media_type)}",
+            used_filenames,
+        )
+        return ResearchArtifact(
+            filename=filename,
+            content_base64="".join(payload.split()),
+            media_type=media_type,
+            source="edison_message_content",
+            description=description or f"Edison image artifact {index}",
+        )
+
+    def _artifact_extension_for_media_type(self, media_type: str) -> str:
+        """Return a filename extension suitable for a MIME type."""
+        extension = mimetypes.guess_extension(media_type)
+        if extension is not None:
+            return extension
+        if media_type == "image/svg+xml":
+            return ".svg"
+        return ".bin"
 
     def _extract_answer_artifacts(
         self,

--- a/src/deep_research_client/providers/falcon.py
+++ b/src/deep_research_client/providers/falcon.py
@@ -6,7 +6,7 @@ import logging
 import mimetypes
 import re
 from pathlib import Path
-from typing import Any, Iterable, List, Optional, Sequence
+from typing import Any, Iterable, List, Optional, Sequence, TypedDict, cast
 from uuid import UUID
 
 from edison_client import EdisonClient, JobNames
@@ -30,6 +30,13 @@ logger = logging.getLogger(__name__)
 _DATA_URL_PREFIX = "data:"
 type EdisonTaskResponse = PQATaskResponse | TaskResponseVerbose
 type EdisonResponse = Sequence[EdisonTaskResponse]
+
+
+class _ImageMessageGroup(TypedDict):
+    """Representative embedded Edison image plus its optional description."""
+
+    url: str
+    description: str | None
 
 
 class FalconProvider(ResearchProvider):
@@ -78,7 +85,7 @@ class FalconProvider(ResearchProvider):
 
         try:
             logger.debug("Making API request to Edison")
-            response = client.run_tasks_until_done(task_data, verbose=True)
+            response = self._coerce_response(client.run_tasks_until_done(task_data, verbose=True))
             logger.info("Edison API request completed successfully")
             return self._result_from_response(client, response, query)
         except Exception as e:
@@ -93,7 +100,7 @@ class FalconProvider(ResearchProvider):
 
         client = EdisonClient(api_key=self.config.api_key)
         logger.info(f"Retrieving Edison trajectory {trajectory_id}")
-        response = [client.get_task(task_id=trajectory_id, verbose=True)]
+        response = self._coerce_response([client.get_task(task_id=trajectory_id, verbose=True)])
         query = response[0].query or f"Edison trajectory {trajectory_id}"
         result = self._result_from_response(client, response, query)
         result.provider_config = {
@@ -126,6 +133,20 @@ class FalconProvider(ResearchProvider):
             provider=self.name,
             query=query,
         )
+
+    def _coerce_response(self, response: Sequence[Any]) -> EdisonResponse:
+        """Validate Edison client responses against the shapes this provider supports."""
+        if not response:
+            raise ValueError("Unexpected Edison response structure: empty response")
+
+        for task_response in response:
+            if not isinstance(task_response, (PQATaskResponse, TaskResponseVerbose)):
+                raise ValueError(
+                    "Expected PQATaskResponse or TaskResponseVerbose, got "
+                    f"{type(task_response)}. This indicates an API change in edison-client."
+                )
+
+        return cast(EdisonResponse, response)
 
     def _extract_text_content(self, response: EdisonResponse) -> str:
         """Extract text content from Edison response.
@@ -294,7 +315,7 @@ class FalconProvider(ResearchProvider):
 
         return artifacts
 
-    def _walk_image_message_groups(self, value: Any) -> Iterable[dict[str, str | None]]:
+    def _walk_image_message_groups(self, value: Any) -> Iterable[_ImageMessageGroup]:
         """Yield one representative image and description per nested message content block."""
         if isinstance(value, dict):
             content = value.get("content")

--- a/src/deep_research_client/providers/falcon.py
+++ b/src/deep_research_client/providers/falcon.py
@@ -6,7 +6,7 @@ import logging
 import mimetypes
 import re
 from pathlib import Path
-from typing import Any, Iterable, List, Optional
+from typing import Any, Iterable, List, Optional, Sequence
 from uuid import UUID
 
 from edison_client import EdisonClient, JobNames
@@ -28,6 +28,8 @@ logger = logging.getLogger(__name__)
 
 
 _DATA_URL_PREFIX = "data:"
+type EdisonTaskResponse = PQATaskResponse | TaskResponseVerbose
+type EdisonResponse = Sequence[EdisonTaskResponse]
 
 
 class FalconProvider(ResearchProvider):
@@ -104,7 +106,7 @@ class FalconProvider(ResearchProvider):
     def _result_from_response(
         self,
         client: EdisonClient,
-        response: list[Any],
+        response: EdisonResponse,
         query: str,
     ) -> ResearchResult:
         """Build a research result from an Edison verbose response."""
@@ -125,7 +127,7 @@ class FalconProvider(ResearchProvider):
             query=query,
         )
 
-    def _extract_text_content(self, response) -> str:
+    def _extract_text_content(self, response: EdisonResponse) -> str:
         """Extract text content from Edison response.
 
         Edison returns PQATaskResponse objects for standard calls. With
@@ -184,7 +186,7 @@ class FalconProvider(ResearchProvider):
 
         return {}
 
-    def _extract_citations(self, response, report_text: str) -> List[str]:
+    def _extract_citations(self, response: EdisonResponse, report_text: str) -> List[str]:
         """Extract citations from Edison response.
 
         Citations are embedded in the formatted_answer text using various patterns.
@@ -215,7 +217,7 @@ class FalconProvider(ResearchProvider):
 
         return []
 
-    def _extract_artifacts(self, client: Any, response: list[Any]) -> list[ResearchArtifact]:
+    def _extract_artifacts(self, client: Any, response: EdisonResponse) -> list[ResearchArtifact]:
         """Fetch artifacts listed in the final Edison environment frame."""
         if not response:
             return []
@@ -261,7 +263,11 @@ class FalconProvider(ResearchProvider):
         used_filenames: set[str],
     ) -> list[ResearchArtifact]:
         """Extract one representative image from each verbose Edison image message."""
-        payload = response.model_dump(mode="python")
+        if self.params.max_embedded_images == 0:
+            return []
+
+        # Only the agent-state message history is needed for embedded images.
+        payload = {"agent_state": response.agent_state}
         artifacts: list[ResearchArtifact] = []
         seen_urls: set[str] = set()
 
@@ -279,6 +285,12 @@ class FalconProvider(ResearchProvider):
             )
             if artifact is not None:
                 artifacts.append(artifact)
+                if len(artifacts) >= self.params.max_embedded_images:
+                    logger.info(
+                        "Reached Falcon embedded image limit (%s); skipping remaining embedded images",
+                        self.params.max_embedded_images,
+                    )
+                    break
 
         return artifacts
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -110,6 +110,18 @@ def test_research_help_lists_openscientist_provider():
     assert "openscientist" in result.stdout
 
 
+def test_edison_trajectory_requires_api_key():
+    """Trajectory retrieval should fail fast when Edison credentials are missing."""
+    with patch.dict(os.environ, {}, clear=True):
+        result = runner.invoke(
+            app,
+            ["edison-trajectory", "784d73d5-da42-402e-9701-6c5b44beab14"],
+        )
+
+    assert result.exit_code == 1
+    assert "EDISON_API_KEY is required" in result.output
+
+
 def test_write_result_artifacts_sets_relative_paths(tmp_path):
     """CLI artifact writer should materialize sidecar files for markdown links."""
     result = ResearchResult(

--- a/tests/test_falcon_provider.py
+++ b/tests/test_falcon_provider.py
@@ -1,5 +1,7 @@
 """Tests for Falcon provider response handling."""
 
+import asyncio
+import base64
 import pytest
 from datetime import datetime
 from pathlib import Path
@@ -8,6 +10,7 @@ from uuid import UUID
 # Skip all tests in this module if edison_client is not installed
 pytest.importorskip("edison_client")
 
+from deep_research_client.providers import falcon as falcon_module
 from deep_research_client.providers.falcon import FalconProvider
 from deep_research_client.models import ProviderConfig
 
@@ -307,6 +310,144 @@ def test_extract_answer_artifacts_from_verbose_response():
     assert artifact.source == "edison_answer_artifacts"
 
 
+def test_extract_message_image_artifacts_from_verbose_response():
+    """Verbose Edison message history images should become durable artifacts."""
+    config = ProviderConfig(name="falcon", api_key="test-key")
+    provider = FalconProvider(config)
+    image_payload = base64.b64encode(b"png-bytes").decode("ascii")
+    response = create_verbose_response(
+        {
+            "state": {
+                "state": {
+                    "response": {
+                        "answer": {
+                            "formatted_answer": "Formatted answer",
+                        }
+                    }
+                }
+            }
+        }
+    )
+    response = response.model_copy(
+        update={
+            "agent_state": [
+                {
+                    "state": {
+                        "transition": {
+                            "agent_state": {
+                                "messages": [
+                                    {
+                                        "content": [
+                                            {
+                                                "type": "image_url",
+                                                "image_url": {
+                                                    "url": f"data:image/png;base64,{image_payload}",
+                                                },
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    )
+
+    artifacts = provider._extract_message_image_artifacts(response, used_filenames=set())
+
+    assert len(artifacts) == 1
+    artifact = artifacts[0]
+    assert artifact.filename == "image-1.png"
+    assert artifact.media_type == "image/png"
+    assert artifact.source == "edison_message_content"
+    assert base64.b64decode(artifact.content_base64) == b"png-bytes"
+
+
+def test_extract_message_image_artifacts_deduplicates_data_urls():
+    """Repeated verbose Edison image URLs should only produce one artifact."""
+    config = ProviderConfig(name="falcon", api_key="test-key")
+    provider = FalconProvider(config)
+    image_payload = base64.b64encode(b"png-bytes").decode("ascii")
+    response = create_verbose_response({"state": {}})
+    response = response.model_copy(
+        update={
+            "agent_state": [
+                {
+                    "messages": [
+                        {
+                            "content": [
+                                {
+                                    "type": "image_url",
+                                    "image_url": {
+                                        "url": f"data:image/png;base64,{image_payload}",
+                                    },
+                                },
+                                {
+                                    "type": "image_url",
+                                    "image_url": {
+                                        "url": f"data:image/png;base64,{image_payload}",
+                                    },
+                                },
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    )
+
+    artifacts = provider._extract_message_image_artifacts(response, used_filenames=set())
+
+    assert [artifact.filename for artifact in artifacts] == ["image-1.png"]
+
+
+def test_extract_message_image_artifacts_keeps_one_image_per_message():
+    """A single Edison image-retrieval message should produce one representative image."""
+    config = ProviderConfig(name="falcon", api_key="test-key")
+    provider = FalconProvider(config)
+    first_payload = base64.b64encode(b"first-png").decode("ascii")
+    second_payload = base64.b64encode(b"second-png").decode("ascii")
+    response = create_verbose_response({"state": {}})
+    response = response.model_copy(
+        update={
+            "agent_state": [
+                {
+                    "messages": [
+                        {
+                            "content": [
+                                {"type": "text", "text": "Retrieved 2 image(s) from paper."},
+                                {"type": "text", "text": "## Context ID: pqac-1\n\nTable 2 crop."},
+                                {
+                                    "type": "image_url",
+                                    "image_url": {
+                                        "url": f"data:image/png;base64,{first_payload}",
+                                    },
+                                },
+                                {
+                                    "type": "image_url",
+                                    "image_url": {
+                                        "url": f"data:image/png;base64,{second_payload}",
+                                    },
+                                },
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    )
+
+    artifacts = provider._extract_message_image_artifacts(response, used_filenames=set())
+
+    assert len(artifacts) == 1
+    artifact = artifacts[0]
+    assert artifact.filename == "image-1.png"
+    assert artifact.description == "## Context ID: pqac-1 Table 2 crop."
+    assert base64.b64decode(artifact.content_base64) == b"first-png"
+
+
 def test_artifact_filename_handles_collisions_and_path_traversal():
     """Provider artifact filenames should be basename-only and unique."""
     config = ProviderConfig(name="falcon", api_key="test-key")
@@ -466,3 +607,95 @@ def test_extract_artifacts_combines_answer_and_output_data_artifacts(tmp_path):
         "artifact-00-2.md",
     ]
     assert client.fetch_calls == [storage_id]
+
+
+def test_research_and_trajectory_return_same_artifacts(monkeypatch):
+    """New Edison research should preserve the same artifacts as trajectory rehydration."""
+
+    image_payload_one = base64.b64encode(b"first-png").decode("ascii")
+    image_payload_two = base64.b64encode(b"second-png").decode("ascii")
+    verbose_response = create_verbose_response(
+        {
+            "state": {
+                "state": {
+                    "response": {
+                        "answer": {
+                            "formatted_answer": "Formatted answer with [PMID:12345678]",
+                            "artifacts": {"artifact-00": "| A | B |\n| - | - |"},
+                        }
+                    }
+                }
+            }
+        }
+    ).model_copy(
+        update={
+            "query": "Original Edison query",
+            "agent_state": [
+                {
+                    "messages": [
+                        {
+                            "content": [
+                                {"type": "text", "text": "Retrieved 2 image(s) from paper."},
+                                {"type": "text", "text": "## Context ID: pqac-1\n\nTable 2 crop."},
+                                {
+                                    "type": "image_url",
+                                    "image_url": {
+                                        "url": f"data:image/png;base64,{image_payload_one}",
+                                    },
+                                },
+                                {
+                                    "type": "image_url",
+                                    "image_url": {
+                                        "url": f"data:image/png;base64,{image_payload_two}",
+                                    },
+                                },
+                            ]
+                        }
+                    ]
+                }
+            ],
+        }
+    )
+
+    class FakeEdisonClient:
+        def __init__(self, api_key: str):
+            self.api_key = api_key
+            self.run_task_calls: list[tuple[dict, bool]] = []
+            self.get_task_calls: list[tuple[str, bool]] = []
+
+        def run_tasks_until_done(self, task_data: dict, verbose: bool = False):
+            self.run_task_calls.append((task_data, verbose))
+            return [verbose_response]
+
+        def get_task(self, task_id: str, verbose: bool = False):
+            self.get_task_calls.append((task_id, verbose))
+            return verbose_response
+
+    created_clients: list[FakeEdisonClient] = []
+
+    def fake_client_factory(api_key: str):
+        client = FakeEdisonClient(api_key)
+        created_clients.append(client)
+        return client
+
+    monkeypatch.setattr(falcon_module, "EdisonClient", fake_client_factory)
+
+    provider = FalconProvider(ProviderConfig(name="falcon", api_key="test-key"))
+    research_result = asyncio.run(provider.research("fresh query"))
+    trajectory_result = provider.retrieve_trajectory("trajectory-123")
+
+    def artifact_signature(result):
+        return [
+            (artifact.filename, artifact.media_type, artifact.source, artifact.description)
+            for artifact in result.artifacts
+        ]
+
+    assert research_result.markdown == trajectory_result.markdown
+    assert research_result.citations == trajectory_result.citations
+    assert artifact_signature(research_result) == artifact_signature(trajectory_result)
+    assert [artifact.filename for artifact in research_result.artifacts] == [
+        "artifact-00.md",
+        "image-1.png",
+    ]
+    assert created_clients[0].run_task_calls[0][1] is True
+    assert created_clients[1].get_task_calls == [("trajectory-123", True)]

--- a/tests/test_falcon_provider.py
+++ b/tests/test_falcon_provider.py
@@ -13,6 +13,7 @@ pytest.importorskip("edison_client")
 from deep_research_client.providers import falcon as falcon_module
 from deep_research_client.providers.falcon import FalconProvider
 from deep_research_client.models import ProviderConfig
+from deep_research_client.provider_params import FalconParams
 
 
 def create_mock_pqa_response(
@@ -446,6 +447,54 @@ def test_extract_message_image_artifacts_keeps_one_image_per_message():
     assert artifact.filename == "image-1.png"
     assert artifact.description == "## Context ID: pqac-1 Table 2 crop."
     assert base64.b64decode(artifact.content_base64) == b"first-png"
+
+
+def test_extract_message_image_artifacts_honors_configured_limit():
+    """Embedded Edison image recovery should stop at the configured maximum."""
+    provider = FalconProvider(
+        ProviderConfig(name="falcon", api_key="test-key"),
+        FalconParams(max_embedded_images=1),
+    )
+    first_payload = base64.b64encode(b"first-png").decode("ascii")
+    second_payload = base64.b64encode(b"second-png").decode("ascii")
+    response = create_verbose_response({"state": {}})
+    response = response.model_copy(
+        update={
+            "agent_state": [
+                {
+                    "messages": [
+                        {
+                            "content": [
+                                {"type": "text", "text": "First image group"},
+                                {
+                                    "type": "image_url",
+                                    "image_url": {
+                                        "url": f"data:image/png;base64,{first_payload}",
+                                    },
+                                },
+                            ]
+                        },
+                        {
+                            "content": [
+                                {"type": "text", "text": "Second image group"},
+                                {
+                                    "type": "image_url",
+                                    "image_url": {
+                                        "url": f"data:image/png;base64,{second_payload}",
+                                    },
+                                },
+                            ]
+                        },
+                    ]
+                }
+            ]
+        }
+    )
+
+    artifacts = provider._extract_message_image_artifacts(response, used_filenames=set())
+
+    assert len(artifacts) == 1
+    assert artifacts[0].description == "First image group"
 
 
 def test_artifact_filename_handles_collisions_and_path_traversal():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -208,6 +208,7 @@ def test_format_research_result_includes_artifact_frontmatter(formatter_class):
         markdown="# Report",
         provider="falcon",
         query="query",
+        provider_config={"trajectory_id": "784d73d5-da42-402e-9701-6c5b44beab14"},
         artifacts=[
             ResearchArtifact(
                 filename="figure.png",
@@ -225,6 +226,8 @@ def test_format_research_result_includes_artifact_frontmatter(formatter_class):
     frontmatter = yaml.safe_load(formatted.split("---", 2)[1])
 
     assert frontmatter["artifact_count"] == 1
+    assert frontmatter["trajectory_id"] == "784d73d5-da42-402e-9701-6c5b44beab14"
+    assert frontmatter["artifact_sources"] == {"edison_output_data": 1}
     assert frontmatter["artifacts"] == [
         {
             "filename": "figure.png",


### PR DESCRIPTION
This pull request introduces a new CLI command to retrieve existing Edison research trajectories by ID, enhances artifact extraction and metadata recording for Edison reports, and improves documentation and test coverage for these features. The main focus is on making Edison trajectory retrieval robust, ensuring artifacts are preserved and clearly documented, and updating the CLI and documentation to reflect these capabilities.

**New CLI command and documentation:**

* Added the `edison-trajectory` command to the CLI, allowing users to retrieve an existing Edison trajectory report and associated artifacts by providing a trajectory ID. This command handles artifact extraction, citation separation, and metadata enrichment. [[1]](diffhunk://#diff-b4fe61f7064ada5717eca23b98238c3ed4a8d7f22a2e6e52c94871dbef190248R573-R637) [[2]](diffhunk://#diff-975000db2bb150ebdc1a762c178c531c19747c5c75a8147bec4a31e69945e711R106-R147)
* Updated the documentation (`README.md`, `docs/reference/cli.md`) with usage examples, command descriptions, and notes about artifact and citation handling for both the new and existing commands. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R84-R86) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L905-R908) [[3]](diffhunk://#diff-975000db2bb150ebdc1a762c178c531c19747c5c75a8147bec4a31e69945e711R50-R51) [[4]](diffhunk://#diff-975000db2bb150ebdc1a762c178c531c19747c5c75a8147bec4a31e69945e711R106-R147)

**Artifact extraction and metadata improvements:**

* Enhanced the Edison provider to extract and preserve image artifacts embedded in message content, ensuring that one representative image per message group is saved and described. [[1]](diffhunk://#diff-57da189a9d8ee7e4f825605b208cee48b083356a5e6f111b4247ecbc832c0759R81-R110) [[2]](diffhunk://#diff-57da189a9d8ee7e4f825605b208cee48b083356a5e6f111b4247ecbc832c0759R229-R234) [[3]](diffhunk://#diff-57da189a9d8ee7e4f825605b208cee48b083356a5e6f111b4247ecbc832c0759R258-R365)
* Improved metadata in report frontmatter: now includes `trajectory_id` and a summary of `artifact_sources` for transparency about artifact provenance. [[1]](diffhunk://#diff-ead7e52979863285ee7fa412b589ef45699402fc4444adaafca4a9f29b556d7fR51-R63) [[2]](diffhunk://#diff-86d38381bb8ca40416ae41729f505db952a019a6b1baf579c16adaf6f90a6026R65-R77)

**Testing and robustness:**

* Added tests to ensure the new `edison-trajectory` command fails gracefully when required API keys are missing and to verify artifact writing behavior.
* Refactored provider and formatter code for better error handling and maintainability, including more robust extraction logic and logging. [[1]](diffhunk://#diff-57da189a9d8ee7e4f825605b208cee48b083356a5e6f111b4247ecbc832c0759L191-R218) [[2]](diffhunk://#diff-57da189a9d8ee7e4f825605b208cee48b083356a5e6f111b4247ecbc832c0759L94-L99) [[3]](diffhunk://#diff-d9ab2bb6f87607e59eba116b99577739f88b9f02603d388030bd9dfb10bdd918R3-R4) [[4]](diffhunk://#diff-d9ab2bb6f87607e59eba116b99577739f88b9f02603d388030bd9dfb10bdd918R13) [[5]](diffhunk://#diff-ead7e52979863285ee7fa412b589ef45699402fc4444adaafca4a9f29b556d7fR3) [[6]](diffhunk://#diff-86d38381bb8ca40416ae41729f505db952a019a6b1baf579c16adaf6f90a6026R3)

These changes collectively make Edison trajectory retrieval more user-friendly, reliable, and transparent, while improving documentation and test coverage.