### PR TITLE
[codex] Preserve OpenScientist artifacts

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,21 +27,23 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
+          # In v1, providing a `prompt` runs in automation mode, which does NOT
+          # post a comment by default. track_progress restores the v0.x
+          # "post the review as a PR comment" behavior and auto-injects PR context.
+          track_progress: true
 
-          # Direct prompt for automated review (no @claude mention needed)
-          direct_prompt: |
+          # Prompt for the automated review (no @claude mention needed).
+          prompt: |
             Please review this pull request and provide feedback on:
             - Code quality and best practices
             - Potential bugs or issues
@@ -50,6 +52,12 @@ jobs:
             - Test coverage
             
             Be constructive and helpful in your feedback.
+
+          # Args passed through to the Claude CLI. Use the `opus` alias rather
+          # than a dated model id so the workflow tracks the current Opus and
+          # won't 404 when a specific version is retired.
+          claude_args: |
+            --model opus
 
           # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
           # use_sticky_comment: true
@@ -75,4 +83,3 @@ jobs:
           # if: |
           #   !contains(github.event.pull_request.title, '[skip-review]') &&
           #   !contains(github.event.pull_request.title, '[WIP]')
-

--- a/README.md
+++ b/README.md
@@ -326,6 +326,8 @@ params = OpenScientistParams(
     investigation_mode="autonomous",  # "autonomous" or "coinvestigate"
     poll_interval=30,              # Seconds between status checks
     timeout=3600,                  # Max wait time in seconds (default 1 hour)
+    save_artifacts=True,           # Preserve useful ZIP artifacts
+    artifact_max_bytes=5 * 1024 * 1024,  # Per-artifact extraction limit
 )
 
 result = client.research(
@@ -336,6 +338,7 @@ result = client.research(
 
 # OpenScientist returns PMID citations
 print(f"Citations: {result.citations}")  # ['PMID:12345678', 'PMID:87654321', ...]
+print(f"Artifacts: {len(result.artifacts)}")
 print(f"Research took: {result.duration_seconds / 60:.1f} minutes")
 ```
 
@@ -903,9 +906,9 @@ deep-research-client research "simple question" --provider perplexity --model so
 | Edison | `EDISON_API_KEY` | Edison Scientific Literature | Scientific literature focus, powered by PaperQA3; preserves output figures and files |
 | Perplexity | `PERPLEXITY_API_KEY` | sonar-deep-research | Real-time web search, recent sources |
 | Consensus | `CONSENSUS_API_KEY` | Consensus Academic Search | Peer-reviewed academic papers, evidence-based research |
-| OpenScientist | `OPENSCIENTIST_API_KEY` | openscientist-autonomous | Iterative hypothesis-driven research, PubMed PMID citations |
+| OpenScientist | `OPENSCIENTIST_API_KEY` | openscientist-autonomous | Iterative hypothesis-driven research, PubMed PMID citations, preserves useful artifacts |
 
-When Edison produces diagrams, charts, figures, or other output artifacts, saved reports include an `Artifacts` section. Both the standard `research` command and `edison-trajectory` materialize recovered artifacts beside the output markdown in a sidecar directory such as `report_artifacts/`, and image artifacts are embedded with relative Markdown links. Rehydrated Edison trajectories also record `trajectory_id` and `artifact_sources` in frontmatter.
+When Edison or OpenScientist produces diagrams, charts, figures, or other useful output artifacts, saved reports include an `Artifacts` section. The standard `research` command materializes recovered artifacts beside the output markdown in a sidecar directory such as `report_artifacts/`, and image artifacts are embedded with relative Markdown links. Rehydrated Edison trajectories also record `trajectory_id` and `artifact_sources` in frontmatter.
 
 ## Development
 

--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -219,6 +219,8 @@ params = OpenScientistParams(
     investigation_mode="autonomous",  # "autonomous" or "coinvestigate"
     poll_interval=30,              # Seconds between status checks
     timeout=3600,                  # Max wait time (1-2 hours recommended)
+    save_artifacts=True,           # Preserve useful ZIP artifacts
+    artifact_max_bytes=5 * 1024 * 1024,  # Per-artifact extraction limit
 )
 ```
 
@@ -228,6 +230,7 @@ params = OpenScientistParams(
 - **Speed**: 10-60+ minutes (iterative multi-step research)
 - **Capabilities**: PubMed search, code execution, hypothesis-driven research
 - **Citations**: PMID format with deduplication
+- **Artifacts**: Useful figures, small structured files, and rendered reports from the OpenScientist artifact ZIP are returned as `ResearchArtifact` entries. Runtime scaffolding, logs, transcripts, archives, and oversized files are skipped by default.
 
 ### When to Use
 

--- a/src/deep_research_client/client.py
+++ b/src/deep_research_client/client.py
@@ -210,7 +210,7 @@ class DeepResearchClient:
         # keep stale cache entries from shadowing current live results.
         if research_provider.name == "asta":
             effective_params["_cache_version"] = "snippet-v5"
-        elif research_provider.name == "falcon":
+        elif research_provider.name in {"falcon", "openscientist"}:
             effective_params["_cache_version"] = "artifacts-v1"
 
         return effective_params or None

--- a/src/deep_research_client/provider_params.py
+++ b/src/deep_research_client/provider_params.py
@@ -273,6 +273,19 @@ class OpenScientistParams(BaseProviderParams):
         le=7200,
         description="Maximum seconds to wait for job completion"
     )
+    save_artifacts: bool = Field(
+        default=True,
+        description=(
+            "Download and preserve useful OpenScientist artifacts such as figures, "
+            "small structured data files, and rendered reports."
+        )
+    )
+    artifact_max_bytes: int = Field(
+        default=5 * 1024 * 1024,
+        ge=1,
+        le=50 * 1024 * 1024,
+        description="Maximum uncompressed bytes to preserve for a single artifact file"
+    )
 
 
 class CyberianParams(BaseProviderParams):

--- a/src/deep_research_client/providers/openscientist.py
+++ b/src/deep_research_client/providers/openscientist.py
@@ -9,15 +9,26 @@ openscientist.io), polls for completion, and downloads the final report.
 """
 
 import asyncio
+import base64
+from dataclasses import dataclass
+import io
 import logging
+import mimetypes
 import os
+from pathlib import PurePosixPath
 import re
 from typing import List, Optional
+import zipfile
 
 import httpx
 
 from . import ResearchProvider
-from ..models import ResearchResult, ProviderConfig
+from ..models import (
+    ResearchArtifact,
+    ResearchResult,
+    ProviderConfig,
+    sanitize_artifact_filename,
+)
 from ..provider_params import OpenScientistParams
 from ..model_cards import ProviderModelCards, create_openscientist_model_cards
 
@@ -29,6 +40,58 @@ IN_PROGRESS_STATUSES = {"pending", "queued", "running", "generating_report", "aw
 
 # Default base URL if not overridden
 DEFAULT_BASE_URL = "https://www.openscientist.io"
+
+
+_ALLOWED_ARTIFACT_EXTENSIONS = {
+    ".csv",
+    ".gif",
+    ".htm",
+    ".html",
+    ".jpeg",
+    ".jpg",
+    ".json",
+    ".md",
+    ".pdf",
+    ".png",
+    ".svg",
+    ".tsv",
+    ".webp",
+}
+_ARCHIVE_ARTIFACT_EXTENSIONS = {
+    ".7z",
+    ".bz2",
+    ".gz",
+    ".tar",
+    ".tgz",
+    ".xz",
+    ".zip",
+}
+_NOISY_ARTIFACT_PREFIXES = (
+    ".cache/",
+    ".claude/",
+    ".git/",
+    ".ipynb_checkpoints/",
+    ".venv/",
+    "__macosx/",
+    "cache/",
+    "node_modules/",
+)
+_NOISY_ARTIFACT_SUFFIXES = (".log", ".tmp")
+_NOISY_ARTIFACT_NAME_FRAGMENTS = (
+    "stderr",
+    "stdout",
+    "transcript",
+)
+_REPORT_MARKDOWN_BASENAMES = {"final_report.md", "report.md"}
+_ARTIFACT_SOURCE = "openscientist_artifacts_zip"
+
+
+@dataclass(frozen=True)
+class _DownloadedOpenScientistReport:
+    """OpenScientist markdown plus selected sidecar artifacts."""
+
+    markdown: str
+    artifacts: list[ResearchArtifact]
 
 
 class OpenScientistProvider(ResearchProvider):
@@ -126,20 +189,23 @@ class OpenScientistProvider(ResearchProvider):
                     f"OpenScientist job {final_status}: {error_msg}"
                 )
 
-            # 4. Download report
-            markdown = await self._download_report(client, job_id)
+            # 4. Download report and selected artifacts
+            download = await self._download_report_with_artifacts(client, job_id)
+            markdown = download.markdown
 
             # 5. Extract citations
             citations = self._extract_citations(markdown)
 
             logger.info(
                 f"OpenScientist research complete: "
-                f"{len(markdown)} chars, {len(citations)} citations"
+                f"{len(markdown)} chars, {len(citations)} citations, "
+                f"{len(download.artifacts)} artifacts"
             )
 
             return ResearchResult(
                 markdown=markdown,
                 citations=citations,
+                artifacts=download.artifacts,
                 provider=self.name,
                 query=query,
                 model=self.model,
@@ -270,26 +336,96 @@ class OpenScientistProvider(ResearchProvider):
         logger.info("Report returned as PDF, trying artifacts endpoint...")
         return await self._extract_markdown_from_artifacts(client, job_id)
 
+    async def _download_report_with_artifacts(
+        self,
+        client: httpx.AsyncClient,
+        job_id: str,
+    ) -> _DownloadedOpenScientistReport:
+        """Download the job report and selected provider artifacts."""
+        url = f"{self.base_url}/api/v1/jobs/{job_id}/report"
+        headers = {**self._headers(), "Accept": "text/markdown"}
+        resp = await client.get(url, headers=headers)
+        resp.raise_for_status()
+
+        content_type = resp.headers.get("content-type", "")
+        if "text/" in content_type or "markdown" in content_type:
+            artifacts = await self._download_artifacts(client, job_id)
+            return _DownloadedOpenScientistReport(markdown=resp.text, artifacts=artifacts)
+
+        logger.info("Report returned as PDF, trying artifacts endpoint...")
+        bundle = await self._download_artifact_bundle(client, job_id)
+        report_name, markdown = self._extract_markdown_from_artifact_zip(bundle, job_id)
+        artifacts = (
+            self._extract_artifacts_from_artifact_zip(bundle, report_names={report_name})
+            if self.params.save_artifacts
+            else []
+        )
+        return _DownloadedOpenScientistReport(markdown=markdown, artifacts=artifacts)
+
+    async def _download_artifacts(
+        self,
+        client: httpx.AsyncClient,
+        job_id: str,
+    ) -> list[ResearchArtifact]:
+        """Download and extract useful OpenScientist sidecar artifacts."""
+        if not self.params.save_artifacts:
+            return []
+
+        try:
+            bundle = await self._download_artifact_bundle(client, job_id)
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code in {404, 405}:
+                logger.info(f"No OpenScientist artifact bundle available for job {job_id}")
+                return []
+            raise
+
+        return self._extract_artifacts_from_artifact_zip(bundle)
+
+    async def _download_artifact_bundle(
+        self,
+        client: httpx.AsyncClient,
+        job_id: str,
+    ) -> bytes:
+        """Download the OpenScientist artifacts ZIP for a completed job."""
+        url = f"{self.base_url}/api/v1/jobs/{job_id}/artifacts"
+        resp = await client.get(url, headers=self._headers())
+        resp.raise_for_status()
+        return resp.content
+
     async def _extract_markdown_from_artifacts(
         self, client: httpx.AsyncClient, job_id: str
     ) -> str:
         """Download artifacts ZIP and extract the markdown report."""
-        import io
-        import zipfile
+        bundle = await self._download_artifact_bundle(client, job_id)
+        return self._extract_markdown_from_artifact_zip(bundle, job_id)[1]
 
-        url = f"{self.base_url}/api/v1/jobs/{job_id}/artifacts"
-        resp = await client.get(url, headers=self._headers())
-        resp.raise_for_status()
-
-        with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
-            # Look for markdown files in the ZIP
+    def _extract_markdown_from_artifact_zip(
+        self,
+        bundle: bytes,
+        job_id: str,
+    ) -> tuple[str, str]:
+        """Extract the best markdown report from an OpenScientist artifact ZIP."""
+        with zipfile.ZipFile(io.BytesIO(bundle)) as zf:
+            zip_names = zf.namelist()
+            # Prefer canonical report filenames over similarly named runtime skills.
             md_files = [
-                n for n in zf.namelist()
-                if n.endswith(".md") and "report" in n.lower()
+                n for n in zip_names
+                if self._is_report_markdown_name(n) and not self._is_noisy_artifact_path(n)
             ]
             if not md_files:
-                # Fall back to any .md file
-                md_files = [n for n in zf.namelist() if n.endswith(".md")]
+                md_files = [
+                    n for n in zip_names
+                    if n.lower().endswith(".md")
+                    and "report" in n.lower()
+                    and not self._is_noisy_artifact_path(n)
+                ]
+            if not md_files:
+                # Fall back to any non-runtime .md file.
+                md_files = [
+                    n for n in zip_names
+                    if n.lower().endswith(".md")
+                    and not self._is_noisy_artifact_path(n)
+                ]
 
             if not md_files:
                 raise ValueError(
@@ -297,12 +433,121 @@ class OpenScientistProvider(ResearchProvider):
                 )
 
             # Read the first matching file
-            with zf.open(md_files[0]) as f:
+            report_name = md_files[0]
+            with zf.open(report_name) as f:
                 raw = f.read()
                 try:
-                    return raw.decode("utf-8")
+                    return report_name, raw.decode("utf-8")
                 except UnicodeDecodeError:
-                    return raw.decode("latin-1")
+                    return report_name, raw.decode("latin-1")
+
+    def _extract_artifacts_from_artifact_zip(
+        self,
+        bundle: bytes,
+        report_names: set[str] | None = None,
+    ) -> list[ResearchArtifact]:
+        """Extract useful sidecar artifacts from an OpenScientist ZIP archive."""
+        report_names = report_names or set()
+        artifacts: list[ResearchArtifact] = []
+        used_filenames: set[str] = set()
+
+        with zipfile.ZipFile(io.BytesIO(bundle)) as zf:
+            for info in sorted(zf.infolist(), key=lambda item: item.filename):
+                if not self._should_preserve_artifact(info, report_names):
+                    continue
+
+                with zf.open(info) as file:
+                    content = file.read()
+
+                filename = self._artifact_filename(info.filename, used_filenames)
+                media_type = mimetypes.guess_type(info.filename)[0]
+                artifacts.append(
+                    ResearchArtifact(
+                        filename=filename,
+                        content_base64=base64.b64encode(content).decode("ascii"),
+                        media_type=media_type,
+                        source=_ARTIFACT_SOURCE,
+                        description=self._artifact_description(info.filename),
+                    )
+                )
+
+        return artifacts
+
+    def _should_preserve_artifact(
+        self,
+        info: zipfile.ZipInfo,
+        report_names: set[str],
+    ) -> bool:
+        """Return whether a ZIP member should become a ResearchArtifact."""
+        if info.is_dir():
+            return False
+
+        name = info.filename
+        if name in report_names:
+            return False
+
+        if self._is_report_markdown_name(name) or self._is_noisy_artifact_path(name):
+            return False
+
+        if info.file_size > self.params.artifact_max_bytes:
+            logger.info(
+                "Skipping OpenScientist artifact %s: %s bytes exceeds %s byte limit",
+                name,
+                info.file_size,
+                self.params.artifact_max_bytes,
+            )
+            return False
+
+        path = PurePosixPath(name.lower())
+        suffix = path.suffix
+        if suffix in _ARCHIVE_ARTIFACT_EXTENSIONS:
+            return False
+
+        media_type = mimetypes.guess_type(name)[0]
+        return suffix in _ALLOWED_ARTIFACT_EXTENSIONS or (
+            media_type is not None and media_type.startswith("image/")
+        )
+
+    def _is_report_markdown_name(self, name: str) -> bool:
+        """Return whether a ZIP member is the markdown report already captured."""
+        path = PurePosixPath(name.lower())
+        return path.name in _REPORT_MARKDOWN_BASENAMES
+
+    def _is_noisy_artifact_path(self, name: str) -> bool:
+        """Return whether a ZIP member is runtime scaffolding or verbose logs."""
+        normalized = PurePosixPath(name).as_posix().lstrip("/").lower()
+        basename = PurePosixPath(normalized).name
+        if normalized.startswith(_NOISY_ARTIFACT_PREFIXES):
+            return True
+        if basename.endswith(_NOISY_ARTIFACT_SUFFIXES):
+            return True
+        return any(fragment in basename for fragment in _NOISY_ARTIFACT_NAME_FRAGMENTS)
+
+    def _artifact_filename(self, raw_name: str, used_filenames: set[str]) -> str:
+        """Return a stable, unique filename for a ZIP artifact member."""
+        filename = sanitize_artifact_filename(raw_name, fallback="artifact")
+        candidate = filename
+        suffix = PurePosixPath(filename).suffix
+        stem = filename.removesuffix(suffix) if suffix else filename
+        stem = stem or "artifact"
+        counter = 2
+
+        while candidate in used_filenames:
+            candidate = f"{stem}-{counter}{suffix}"
+            counter += 1
+
+        used_filenames.add(candidate)
+        return candidate
+
+    def _artifact_description(self, name: str) -> str:
+        """Build a short human-readable artifact description."""
+        path = PurePosixPath(name)
+        stem = path.stem.replace("_", " ").replace("-", " ").strip()
+        if path.name.lower() == "final_report.pdf":
+            return "OpenScientist final report"
+        if stem:
+            return f"OpenScientist {stem}"
+        return f"OpenScientist artifact {path.name}"
 
     @staticmethod
     def _extract_citations(markdown: str) -> List[str]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,11 +62,12 @@ def test_research_rejects_conflicting_query_sources(tmp_path):
 
 def test_providers_asta_shows_required_credentials():
     """CLI should explain that Asta needs its retrieval credential."""
-    result = runner.invoke(
-        app,
-        ["providers", "--provider", "asta"],
-        env={},
-    )
+    with patch.dict(os.environ, {}, clear=True):
+        result = runner.invoke(
+            app,
+            ["providers", "--provider", "asta"],
+            env={},
+        )
 
     assert result.exit_code == 0, result.output
     assert "Provider: asta - Not available" in result.stdout
@@ -75,11 +76,12 @@ def test_providers_asta_shows_required_credentials():
 
 def test_providers_openscientist_shows_required_credentials():
     """CLI should explain that OpenScientist needs its API key."""
-    result = runner.invoke(
-        app,
-        ["providers", "--provider", "openscientist"],
-        env={},
-    )
+    with patch.dict(os.environ, {}, clear=True):
+        result = runner.invoke(
+            app,
+            ["providers", "--provider", "openscientist"],
+            env={},
+        )
 
     assert result.exit_code == 0, result.output
     assert "Provider: openscientist - Not available" in result.stdout
@@ -88,11 +90,12 @@ def test_providers_openscientist_shows_required_credentials():
 
 def test_providers_no_available_providers_mentions_openscientist():
     """CLI should mention OpenScientist in missing-credential guidance."""
-    result = runner.invoke(
-        app,
-        ["providers"],
-        env={},
-    )
+    with patch.dict(os.environ, {}, clear=True):
+        result = runner.invoke(
+            app,
+            ["providers"],
+            env={},
+        )
 
     assert result.exit_code == 0, result.output
     assert "OPENSCIENTIST_API_KEY for OpenScientist" in result.stdout

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -13,6 +13,7 @@ from deep_research_client import DeepResearchClient, ResearchResult, ProviderCon
 from deep_research_client.providers import ResearchProvider
 from deep_research_client.providers.asta import AstaProvider
 from deep_research_client.providers.falcon import FalconProvider
+from deep_research_client.providers.openscientist import OpenScientistProvider
 
 
 class MockProvider(ResearchProvider):
@@ -177,6 +178,20 @@ def test_falcon_cache_params_include_artifact_version_tag():
 
     provider = FalconProvider(ProviderConfig(
         name="falcon", api_key="edison-key", enabled=True))
+    cache_params = client._get_cache_provider_params(provider)
+
+    assert cache_params == {"_cache_version": "artifacts-v1"}
+
+
+def test_openscientist_cache_params_include_artifact_version_tag():
+    """OpenScientist cache keys should invalidate stale no-artifact entries."""
+    cache_config = CacheConfig(enabled=False)
+    with patch.dict(os.environ, {}, clear=True):
+        client = DeepResearchClient(cache_config=cache_config)
+
+    provider = OpenScientistProvider(
+        ProviderConfig(name="openscientist", api_key="opensci-key", enabled=True)
+    )
     cache_params = client._get_cache_provider_params(provider)
 
     assert cache_params == {"_cache_version": "artifacts-v1"}

--- a/tests/test_openscientist_provider.py
+++ b/tests/test_openscientist_provider.py
@@ -1,15 +1,20 @@
 """Tests for the OpenScientist provider."""
 
 import asyncio
+import base64
 import io
 import os
 import zipfile
 from pathlib import Path
+from types import SimpleNamespace
 
 import httpx
 import pytest
+import yaml
 
-from deep_research_client.models import ProviderConfig
+from deep_research_client.cli import _write_result_artifacts
+from deep_research_client.models import ProviderConfig, ResearchArtifact, ResearchResult
+from deep_research_client.processing.result_formatter import ResultFormatter
 from deep_research_client.provider_params import OpenScientistParams
 from deep_research_client.providers.openscientist import OpenScientistProvider
 
@@ -34,7 +39,7 @@ def _load_openscientist_base_url() -> str:
     return os.getenv("OPENSCIENTIST_URL", "https://www.openscientist.io").strip()
 
 
-def create_zip_bytes(files: dict[str, str]) -> bytes:
+def create_zip_bytes(files: dict[str, str | bytes]) -> bytes:
     """Create an in-memory ZIP archive for artifact download tests."""
     buffer = io.BytesIO()
     with zipfile.ZipFile(buffer, "w") as archive:
@@ -321,6 +326,106 @@ class TestOpenScientistProvider:
 
         assert markdown == "# Final Report\n\nPMID: 12345678"
 
+    def test_extract_markdown_from_artifacts_prefers_final_report(self):
+        """Runtime skill files mentioning reports should not shadow the real report."""
+        zip_bytes = create_zip_bytes(
+            {
+                ".claude/skills/clinical-reports--clinical-reports.md": "wrong",
+                "final_report.md": "# Final Report\n\nPMID: 12345678",
+            }
+        )
+
+        report_name, markdown = self.provider._extract_markdown_from_artifact_zip(
+            zip_bytes,
+            "job-123",
+        )
+
+        assert report_name == "final_report.md"
+        assert markdown == "# Final Report\n\nPMID: 12345678"
+
+    def test_extract_artifacts_from_zip_filters_useful_files(self):
+        """OpenScientist artifact ZIP extraction should keep useful review artifacts."""
+        png_content = b"\x89PNG\r\n\x1a\nimage"
+        zip_bytes = create_zip_bytes(
+            {
+                ".claude/skills/runtime.md": "runtime scaffolding",
+                "agent-container.log": "log output",
+                "final_report.md": "# Report",
+                "final_report.pdf": b"%PDF-1.4 fake",
+                "provenance/evidence_matrix.json": '{"rows":[]}',
+                "provenance/evidence_matrix.png": png_content,
+                "provenance/iter1_transcript.json": '{"messages":[]}',
+                "raw/archive.zip": b"PK",
+                "results/table.csv": "gene,score\nATP7B,0.9\n",
+            }
+        )
+
+        artifacts = self.provider._extract_artifacts_from_artifact_zip(
+            zip_bytes,
+            report_names={"final_report.md"},
+        )
+
+        assert [artifact.filename for artifact in artifacts] == [
+            "final_report.pdf",
+            "provenance_evidence_matrix.json",
+            "provenance_evidence_matrix.png",
+            "results_table.csv",
+        ]
+        assert [artifact.source for artifact in artifacts] == [
+            "openscientist_artifacts_zip",
+            "openscientist_artifacts_zip",
+            "openscientist_artifacts_zip",
+            "openscientist_artifacts_zip",
+        ]
+        assert artifacts[2].media_type == "image/png"
+        assert base64.b64decode(artifacts[2].content_base64) == png_content
+
+    def test_extract_artifacts_from_zip_enforces_size_limit(self):
+        """Artifacts larger than the configured limit should be skipped before readout."""
+        provider = OpenScientistProvider(
+            self.config,
+            OpenScientistParams(artifact_max_bytes=3),
+        )
+        zip_bytes = create_zip_bytes(
+            {
+                "provenance/large.png": b"1234",
+                "provenance/small.json": "{}",
+            }
+        )
+
+        artifacts = provider._extract_artifacts_from_artifact_zip(zip_bytes)
+
+        assert [artifact.filename for artifact in artifacts] == [
+            "provenance_small.json"
+        ]
+
+    def test_openscientist_artifacts_write_and_render(self, tmp_path):
+        """OpenScientist artifacts should become sidecars, frontmatter, and links."""
+        zip_bytes = create_zip_bytes(
+            {
+                "provenance/evidence_matrix.json": '{"rows":[]}',
+                "provenance/evidence_matrix.png": b"\x89PNG\r\n\x1a\nimage",
+            }
+        )
+        artifacts = self.provider._extract_artifacts_from_artifact_zip(zip_bytes)
+        result = ResearchResult(
+            markdown="# Report",
+            provider="openscientist",
+            query="query",
+            artifacts=artifacts,
+        )
+
+        _write_result_artifacts(result, tmp_path / "report.md")
+        rendered = ResultFormatter().format_full_markdown(result)
+        frontmatter = yaml.safe_load(rendered.split("---", 2)[1])
+
+        assert (tmp_path / "report_artifacts" / "provenance_evidence_matrix.png").exists()
+        assert frontmatter["artifact_count"] == 2
+        assert frontmatter["artifact_sources"] == {"openscientist_artifacts_zip": 2}
+        assert frontmatter["artifacts"][0]["path"].startswith("report_artifacts/")
+        assert "- [OpenScientist evidence matrix](report_artifacts/provenance_evidence_matrix.json)" in rendered
+        assert "![OpenScientist evidence matrix](report_artifacts/provenance_evidence_matrix.png)" in rendered
+
     async def test_research_success(self, monkeypatch):
         """Test the main research orchestration path."""
         async def fake_health_check(self, client) -> None:
@@ -337,9 +442,19 @@ class TestOpenScientistProvider:
             assert poll_interval == 30
             return "completed"
 
-        async def fake_download_report(self, client, job_id: str) -> str:
+        async def fake_download_report_with_artifacts(self, client, job_id: str):
             assert job_id == "job-123"
-            return "# Report\n\nPMID: 12345678\n\nPMID: 23456789"
+            return SimpleNamespace(
+                markdown="# Report\n\nPMID: 12345678\n\nPMID: 23456789",
+                artifacts=[
+                    ResearchArtifact(
+                        filename="figure.png",
+                        content_base64="aW1hZ2U=",
+                        media_type="image/png",
+                        source="openscientist_artifacts_zip",
+                    )
+                ],
+            )
 
         monkeypatch.setattr(
             "deep_research_client.providers.openscientist.httpx.AsyncClient",
@@ -348,7 +463,11 @@ class TestOpenScientistProvider:
         monkeypatch.setattr(OpenScientistProvider, "_health_check", fake_health_check)
         monkeypatch.setattr(OpenScientistProvider, "_submit_job", fake_submit_job)
         monkeypatch.setattr(OpenScientistProvider, "_poll_until_done", fake_poll_until_done)
-        monkeypatch.setattr(OpenScientistProvider, "_download_report", fake_download_report)
+        monkeypatch.setattr(
+            OpenScientistProvider,
+            "_download_report_with_artifacts",
+            fake_download_report_with_artifacts,
+        )
 
         result = await self.provider.research("What is autophagy?")
 
@@ -357,6 +476,7 @@ class TestOpenScientistProvider:
         assert result.model == "openscientist-autonomous"
         assert result.markdown == "# Report\n\nPMID: 12345678\n\nPMID: 23456789"
         assert result.citations == ["PMID:12345678", "PMID:23456789"]
+        assert [artifact.filename for artifact in result.artifacts] == ["figure.png"]
 
     async def test_research_timeout_cancels_job(self, monkeypatch):
         """Test timeout handling cancels the submitted job."""

--- a/tests/test_provider_params.py
+++ b/tests/test_provider_params.py
@@ -185,6 +185,8 @@ def test_create_provider_params_openscientist():
             "investigation_mode": "coinvestigate",
             "poll_interval": 15,
             "timeout": 900,
+            "save_artifacts": False,
+            "artifact_max_bytes": 1024,
         }
     )
 
@@ -195,6 +197,8 @@ def test_create_provider_params_openscientist():
     assert params.investigation_mode == "coinvestigate"
     assert params.poll_interval == 15
     assert params.timeout == 900
+    assert params.save_artifacts is False
+    assert params.artifact_max_bytes == 1024
 
 
 def test_allowed_domains_max_limit_documented():


### PR DESCRIPTION
## Summary

Fixes #49.

This PR adds OpenScientist artifact preservation using the existing `ResearchResult.artifacts` contract. Completed OpenScientist jobs now download the provider artifact ZIP, keep useful review artifacts, and return them as `ResearchArtifact` entries so the existing CLI sidecar writer and Markdown formatter can persist and link them.

## What changed

- Extract useful OpenScientist artifact ZIP entries, including images, small structured data files, HTML, and PDF reports.
- Skip noisy/default-unsafe entries such as logs, transcripts, runtime scaffolding, archives, cache paths, and oversized files.
- Add `OpenScientistParams.save_artifacts` and `OpenScientistParams.artifact_max_bytes` controls.
- Add an OpenScientist cache version tag so older cached no-artifact results do not shadow new behavior.
- Document the new artifact behavior and parameters.
- Harden CLI credential tests so local API keys do not affect no-key assertions.

## Root cause

The OpenScientist provider only used the artifact ZIP as a fallback source for Markdown reports and discarded the rest of the bundle. That lost figures and structured provenance files that downstream hypothesis-review workflows need.

## Validation

- `just test`
  - pytest: `282 passed, 17 deselected`
  - mypy: no issues found
  - ruff: all checks passed
- Live extraction check against OpenScientist job `054b7222-7873-4924-9167-684a517b4c99`
  - selected `final_report.md`
  - returned 43,337 markdown characters
  - extracted 20 selected artifacts