### PR TITLE
Add Claude Code deep research provider (closes #55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ result = client.research(
 - No API key required — auth/billing is handled by your local Claude Code installation.
 - Auto-detected whenever `claude` is on PATH; set `DISABLE_CLAUDE_CODE_PROVIDER=true` to opt out.
 - **Security:** by default the agent is restricted to a read-only research toolset (`allowed_tools` = `["WebSearch", "WebFetch"]`), so even an untrusted query cannot edit files or run shell commands. Setting `skip_permissions=True` adds `--dangerously-skip-permissions`, which bypasses all permission checks and **makes `allowed_tools` a no-op** (all tools become available) — use it only in trusted, sandboxed environments.
+- **Reading local documents:** the default toolset is web-only and omits the `Read` tool. To research over files you supply (e.g. via `add_dirs`), add `Read` to `allowed_tools` explicitly: `allowed_tools=["WebSearch", "WebFetch", "Read"]`. It is left out by default because filesystem read access is unnecessary for web research and is a mild information-disclosure surface for untrusted queries.
 
 #### OpenScientist-Specific Parameters (Autonomous Research)
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 # deep-research-client
 
-A simple Python wrapper for multiple deep research tools including OpenAI Deep Research, Edison Scientific (formerly FutureHouse Falcon), Asta scientific corpus retrieval, Perplexity AI, Consensus Academic Search, Cyberian agent-based research, and OpenScientist autonomous research.
+A simple Python wrapper for multiple deep research tools including OpenAI Deep Research, Edison Scientific (formerly FutureHouse Falcon), Asta scientific corpus retrieval, Perplexity AI, Consensus Academic Search, Cyberian agent-based research, OpenScientist autonomous research, and Claude Code.
 
 ## Features
 
-- 🔍 **Multiple Providers**: Support for OpenAI Deep Research, Edison Scientific, Asta, Perplexity AI, Consensus, Cyberian (agent-based), and OpenScientist (autonomous)
+- 🔍 **Multiple Providers**: Support for OpenAI Deep Research, Edison Scientific, Asta, Perplexity AI, Consensus, Cyberian (agent-based), OpenScientist (autonomous), and Claude Code (local CLI)
 - 📚 **Rich Output**: Returns comprehensive markdown reports with citations
 - 💾 **Smart Caching**: File-based caching to avoid expensive re-queries
 - 🔧 **Simple Configuration**: Auto-detects providers from environment variables
@@ -62,6 +62,10 @@ export OPENSCIENTIST_URL="https://www.openscientist.io"
 # For Cyberian (agent-based research) - requires cyberian installation
 pip install deep-research-client[cyberian]
 # Cyberian uses your local AI agents (Claude, etc.) - no separate API key needed
+
+# For Claude Code - just install the `claude` CLI and have it authenticated.
+# Auto-detected when `claude` is on PATH; no separate API key needed.
+# Set DISABLE_CLAUDE_CODE_PROVIDER=true to opt out of auto-detection.
 ```
 
 Note: the Asta provider is retrieval-only and does not consume prompts verbatim. Markdown-heavy or template-style inputs are pre-processed into plain text before submission, and long inputs are truncated to the configured `query_char_limit` (500 characters by default).
@@ -297,6 +301,34 @@ print(f"Research took: {result.duration_seconds / 60:.1f} minutes")
 - 💰 **Variable cost**: Depends on agent and research depth
 - 🖥️ **Local compute**: Requires agentapi and agent setup
 - 🎯 **Thorough**: More comprehensive than API-based providers
+
+#### Claude Code-Specific Parameters (Local CLI)
+
+Claude Code is a local command-line tool rather than an HTTP API. This provider runs the `claude` binary in non-interactive ("print") mode, pipes the prompt to it via stdin, and lets Claude Code's own agentic tools (web search, web fetch, file reading) carry out the research.
+
+```python
+from deep_research_client.provider_params import ClaudeCodeParams
+
+params = ClaudeCodeParams(
+    model="opus",                  # optional; forwarded to `claude --model`
+    skip_permissions=True,         # adds --dangerously-skip-permissions (default)
+    allowed_tools=["WebSearch", "WebFetch"],  # optional --allowedTools allowlist
+    add_dirs=["/data/papers"],     # optional --add-dir entries
+    working_dir=None,              # optional cwd for the run
+    extra_args=["--max-turns", "30"],  # escape hatch for unmodeled flags
+)
+
+result = client.research(
+    "What are the mechanisms of autophagy in cancer?",
+    provider="claude_code",
+    provider_params=params
+)
+```
+
+**Notes:**
+- No API key required — auth/billing is handled by your local Claude Code installation.
+- Auto-detected whenever `claude` is on PATH; set `DISABLE_CLAUDE_CODE_PROVIDER=true` to opt out.
+- Non-interactive runs typically need `--dangerously-skip-permissions` (recommended only in trusted/sandboxed environments).
 
 #### OpenScientist-Specific Parameters (Autonomous Research)
 

--- a/README.md
+++ b/README.md
@@ -311,8 +311,8 @@ from deep_research_client.provider_params import ClaudeCodeParams
 
 params = ClaudeCodeParams(
     model="opus",                  # optional; forwarded to `claude --model`
-    skip_permissions=True,         # adds --dangerously-skip-permissions (default)
-    allowed_tools=["WebSearch", "WebFetch"],  # optional --allowedTools allowlist
+    allowed_tools=["WebSearch", "WebFetch"],  # tool allowlist (default: read-only research set)
+    skip_permissions=False,        # default; True bypasses ALL checks (see below)
     add_dirs=["/data/papers"],     # optional --add-dir entries
     working_dir=None,              # optional cwd for the run
     extra_args=["--max-turns", "30"],  # escape hatch for unmodeled flags
@@ -328,7 +328,7 @@ result = client.research(
 **Notes:**
 - No API key required — auth/billing is handled by your local Claude Code installation.
 - Auto-detected whenever `claude` is on PATH; set `DISABLE_CLAUDE_CODE_PROVIDER=true` to opt out.
-- Non-interactive runs typically need `--dangerously-skip-permissions` (recommended only in trusted/sandboxed environments).
+- **Security:** by default the agent is restricted to a read-only research toolset (`allowed_tools` = `["WebSearch", "WebFetch"]`), so even an untrusted query cannot edit files or run shell commands. Setting `skip_permissions=True` adds `--dangerously-skip-permissions`, which bypasses all permission checks and **makes `allowed_tools` a no-op** (all tools become available) — use it only in trusted, sandboxed environments.
 
 #### OpenScientist-Specific Parameters (Autonomous Research)
 

--- a/docs/examples/claude-code-deep-research-example.md
+++ b/docs/examples/claude-code-deep-research-example.md
@@ -1,0 +1,212 @@
+---
+provider: claude_code
+model: claude-haiku-4-5-20251001, claude-opus-4-8[1m]
+cached: false
+start_time: '2026-06-24T12:49:56.149501'
+end_time: '2026-06-24T12:52:46.986655'
+duration_seconds: 170.84
+provider_config:
+  timeout: 1800
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    claude_executable: claude
+    skip_permissions: true
+    allowed_tools: []
+    add_dirs: []
+    extra_args: []
+run_metadata:
+  models_used:
+  - claude-haiku-4-5-20251001
+  - claude-opus-4-8[1m]
+  web_search_requests: 9
+  num_turns: 13
+  total_cost_usd: 0.876082
+  session_id: 407d7c21-3388-4a47-9c08-e90ec8ace078
+  stop_reason: end_turn
+citation_count: 24
+---
+
+## Question
+
+What is known about the role of the gut microbiome in Parkinson's disease, based on recent research?
+
+## Output
+
+I have enough to write a comprehensive report. Here it is.
+
+---
+
+# The Gut Microbiome in Parkinson's Disease: A Research Report
+
+*Compiled June 2026 — prioritizing 2022–2026 sources*
+
+## Executive Summary
+
+Over the past decade, Parkinson's disease (PD) has been reframed by a growing body of evidence from a brain-only disorder into one with deep roots in the gut. The picture that has emerged is something like a garden whose soil chemistry has quietly shifted years before the visible plants wilt: the community of microbes in the PD gut is measurably reorganized — fewer of the calming, butter-making "good neighbor" bacteria and more of the inflammatory, toxin-producing troublemakers — and these changes appear *before* the classic tremor and stiffness ever show up. Large metagenomic studies, mechanistic work on alpha-synuclein (the misfolding protein at PD's core), epidemiology, and the first randomized fecal-transplant trials now converge on the idea that the gut is not a bystander but, for at least a subset of patients, a starting line and an actionable target. Important caveats remain: most human data are associational, microbial signatures vary across populations, and no microbiome therapy is yet proven to alter disease course.
+
+---
+
+## 1. Key Concepts and Current Understanding
+
+### The gut–brain axis and Braak's hypothesis
+The central organizing idea is the **gut–microbiome–brain axis** — a bidirectional communication network linking intestinal microbes to the central nervous system via the vagus nerve, the immune system, and circulating microbial metabolites. In 2003, Heiko Braak proposed that PD pathology may **begin in the gut** and ascend to the brain: alpha-synuclein misfolding starts in the enteric nervous system and spreads "caudo-rostrally" (bottom-up) along the vagus nerve to the brainstem and eventually the substantia nigra, where dopamine neurons die ([Braak hypothesis review, PMC5304413](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5304413/)).
+
+Alpha-synuclein behaves in a **prion-like** manner — a misfolded copy templates the misfolding of its healthy neighbors, a self-propagating chain reaction. Experimental models show **vagus-dependent spread** of this pathology from the gut to the brain, and gut mucosal cells have been shown to physically transfer alpha-synuclein to the vagus nerve ([JCI Insight, 2023](https://insight.jci.org/articles/view/172192); [Neural Regeneration Research, 2023, PMC10358673](https://pmc.ncbi.nlm.nih.gov/articles/PMC10358673/)).
+
+### Supporting epidemiology
+- **Vagotomy:** Large population studies find that **full truncal vagotomy** (surgically cutting the vagus nerve) is associated with reduced PD risk more than five years later — consistent with the gut-to-brain route ([Neural Regeneration Research, 2023](https://pmc.ncbi.nlm.nih.gov/articles/PMC10358673/)).
+- **The appendix** has been proposed as an early reservoir of enteric alpha-synuclein, though appendectomy data are mixed — one meta-analysis found no association with PD risk, another found a decreased risk ([Appendectomy meta-analysis, PMC12320529](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC12320529/)).
+- **Prodromal GI symptoms:** Constipation, often present years to decades before motor onset, is one of the most consistent prodromal (pre-diagnostic) features, supporting an early gut involvement.
+
+---
+
+## 2. What Changes in the PD Gut: The Microbial Signature
+
+### The landmark metagenomic study (Wallen et al., 2022)
+The most influential single dataset is **Wallen et al., *Nature Communications* (2022)** — deep shotgun metagenomic sequencing of **490 PD patients and 234 controls**, the largest high-resolution cohort of its kind ([Nature Communications, 2022, PMC9663292](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC9663292/)). Key findings:
+
+- **Widespread dysbiosis:** Roughly **30% of all species, genes, and pathways tested were altered** — specifically 84 of 257 species (33%) and 34 of 107 genera (32%).
+- **Increased in PD:**
+  - Opportunistic pathogens — *Escherichia coli*, *Klebsiella* spp., *Porphyromonas asaccharolytica*
+  - Counterintuitively, **probiotic-type bacteria** — 7 *Bifidobacterium* species and 6 *Lactobacillus* species were elevated (likely partly driven by supplement use and altered gut chemistry)
+  - *Streptococcus mutans* (~6-fold) and *Actinomyces oris* (~6.5-fold)
+- **Decreased in PD:**
+  - **Short-chain fatty acid (SCFA) producers** — *Roseburia* (up to 7.5-fold lower), *Faecalibacterium prausnitzii*, *Blautia wexlerae* (~5-fold lower)
+  - *Prevotella copri*, *Eubacterium* spp.
+
+### A "disease-permissive" environment
+The authors describe the PD microbiome as **"disease-permissive"** — an overabundance of pathogens and immunogenic (inflammation-triggering) components, paired with depletion of anti-inflammatory and neuroprotective factors. Mechanistically relevant features:
+- **Elevated lipopolysaccharide (LPS) synthesis genes** from gram-negative bacteria → immune activation via TLR4 signaling
+- **Increased curli protein genes** (from *Enterobacteriaceae*) — curli is a bacterial amyloid that **seeds alpha-synuclein aggregation**
+- **Elevated trimethylamine (TMA)** production, linked to neuroinflammation
+- **Reduced** neuroprotective molecules (nicotinamide, trehalose) and a ~2.5-fold reduction in SCFA-producing capacity
+- Depleted sporulation genes and altered tryptophan/serotonin and glutamate/GABA metabolism
+
+### Convergence across cohorts
+Independent large studies broadly agree on the *direction* of change even where exact taxa differ:
+- **Boktor et al., *Movement Disorders* (2023)** — an integrated multi-cohort meta-analysis confirming reproducible shifts in commensals including *Roseburia*, *Lachnospiraceae*, *Blautia*, *Prevotella*, *Faecalibacterium*, and *Eubacterium* ([Movement Disorders, 2023](https://movementdisorders.onlinelibrary.wiley.com/doi/10.1002/mds.29300)).
+- **Palacios et al., *Annals of Neurology* (2023)** — nested case-control within the Nurses' Health Study and Health Professionals Follow-up Study (420 participants) showing metagenomic changes detectable in **prodromal** PD ([Annals of Neurology, 2023](https://onlinelibrary.wiley.com/doi/10.1002/ana.26719)).
+
+The broad consensus across 2024 reviews: **reduced microbial diversity**, a relative **drop in *Firmicutes* and rise in *Proteobacteria***, decreased SCFA producers, and increased pro-inflammatory taxa — changes seen even in **early-stage and drug-naïve patients**, arguing they are not merely consequences of medication ([MDPI *Biomedicines*, 2024](https://www.mdpi.com/2227-9059/12/8/1738); [PMC11624045, 2024](https://pmc.ncbi.nlm.nih.gov/articles/PMC11624045/)).
+
+### Emerging culprit: *Desulfovibrio*
+A 2025 thread of research highlights **sulfate-reducing *Desulfovibrio*** bacteria, consistently increased in PD and in REM-sleep behavior disorder (a strong PD precursor). These microbes produce **hydrogen sulfide** and may directly promote alpha-synuclein aggregation; a 2025 *npj Parkinson's Disease* study showed strain-specific neurodegenerative effects in a *C. elegans* model ([npj Parkinson's Disease, 2025](https://www.nature.com/articles/s41531-025-01102-z)).
+
+---
+
+## 3. Mechanisms Linking Microbiome to PD
+
+Current models propose several intertwined routes:
+
+1. **Intestinal barrier breakdown ("leaky gut")** — proteolytic, mucin-degrading activity erodes the gut lining, letting bacterial products into circulation.
+2. **Neuroinflammation** — LPS and other immunogens activate the immune system, raising pro-inflammatory cytokines and activating microglia (the brain's resident immune cells).
+3. **Direct alpha-synuclein seeding** — bacterial amyloids (curli) and metabolites template misfolding in the enteric nervous system.
+4. **Vagal transmission** — misfolded alpha-synuclein propagates up the vagus nerve to the brainstem.
+5. **Loss of protective metabolites** — depleted SCFAs (butyrate, propionate, acetate) weaken gut barrier integrity, anti-inflammatory tone, and possibly dopamine-related signaling.
+6. **Altered neurotransmitter metabolism** — shifts in tryptophan/serotonin and glutamate/GABA pathways.
+
+A 2025 meta-analysis framed PD's microbiome as enriched in **proinflammatory and "GABA-eating" bacteria** ([PMC12134241, 2025](https://pmc.ncbi.nlm.nih.gov/articles/PMC12134241/)).
+
+---
+
+## 4. The Microbiome and PD Medication (Levodopa)
+
+A particularly practical discovery: **gut bacteria metabolize levodopa**, the cornerstone PD drug, *before* it reaches the brain.
+- ***Enterococcus faecalis*** expresses a highly conserved **tyrosine decarboxylase (TyrDC)** that converts levodopa to dopamine in the gut, lowering bioavailability ([Maini Rekdal et al., *Science*, 2019](https://www.science.org/doi/10.1126/science.aau6323); [van Kessel et al., *Nature Communications*, 2019](https://www.nature.com/articles/s41467-019-08294-y)).
+- ***Eggerthella lenta*** then converts that dopamine to *m*-tyramine, a two-species "interspecies pathway."
+- A **2025 *npj Parkinson's Disease*** study linked *E. faecalis* and *tyrDC* gene levels to real-world levodopa pharmacokinetics in patients ([npj Parkinson's Disease, 2025](https://www.nature.com/articles/s41531-025-00903-6)).
+
+This explains some of the notorious patient-to-patient variability in drug response and opens a path to **small-molecule TyrDC inhibitors** as adjuncts.
+
+---
+
+## 5. Therapeutic Approaches and Clinical Trials
+
+### Fecal Microbiota Transplantation (FMT)
+The most striking recent clinical evidence comes from randomized FMT trials:
+
+- **GUT-PARFECT (Bruggeman et al., *eClinicalMedicine*, 2024)** — a double-blind, placebo-controlled phase 2 trial; a **single FMT** in 46 mild-to-moderate PD patients. After 12 months, the **MDS-UPDRS motor score improved by 5.8 points** in the healthy-donor group vs. 2.7 in placebo (p = 0.0235), with only transient abdominal discomfort as a side effect. Conclusion: a single FMT induced "mild but long-lasting beneficial effects on motor symptoms" in early PD ([eClinicalMedicine, 2024](https://www.thelancet.com/journals/eclinm/article/PIIS2589-5370(24)00142-1/fulltext)).
+- **Finnish trial (Scheperjans et al., *JAMA Neurology*, 2024)** — double-blind, placebo-controlled, 47 patients, 12-month follow-up ([JAMA Neurology, 2024](https://jamanetwork.com/journals/jamaneurology/fullarticle/2821254)).
+- **DuPont et al. pilot (*Frontiers in Neurology*, 2023)** — repeat-dose FMT was safe and tolerable, with reductions in motor OFF time and non-motor symptoms that were **not sustained** through 6 months ([Frontiers in Neurology, 2023](https://www.frontiersin.org/journals/neurology/articles/10.3389/fneur.2023.1104759/full)).
+
+Across trials, FMT is **safe and tolerable**, with **suggestive but not definitive** efficacy signals. An accompanying commentary cautioned about getting the methodology "right, if not PARFECT" ([*J Parkinsons Dis*, 2024](https://journals.sagepub.com/doi/10.3233/JPD-249007)).
+
+### Probiotics and Prebiotics
+The strongest, most consistent benefit is for **constipation**:
+- A **2023 meta-analysis** (12 studies, ~8,181 patients) found probiotics improved constipation and stool frequency, with reported improvements also in motor symptoms, anxiety, and depression ([PMC9990363, 2023](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC9990363/)).
+- A randomized trial of *Lacticaseibacillus paracasei* Shirota improved non-motor and constipation symptoms ([PMC10728848, 2023](https://pmc.ncbi.nlm.nih.gov/articles/PMC10728848/)).
+- A **four-strain probiotic RCT (Leta et al., *Movement Disorders*, 2025)** showed enrichment of beneficial gut bacteria, reduced systemic inflammation, and reduced non-motor symptom burden ([Movement Disorders, 2025](https://movementdisorders.onlinelibrary.wiley.com/doi/10.1002/mds.70047)).
+
+*Lactobacillus* and *Bifidobacterium* dominate probiotic research; **prebiotic** (fiber-based) research remains limited but promising. A practical 2024 clinical guide notes the evidence best supports probiotics/prebiotics for GI symptoms, not yet for slowing neurodegeneration ([*J Parkinsons Dis*, 2024](https://journals.sagepub.com/doi/10.3233/JPD-240172)).
+
+---
+
+## 6. Expert Consensus, Limitations, and Outlook
+
+**Where experts agree (2024–2026 reviews):**
+- A reproducible PD-associated dysbiotic signature exists and is detectable early, even in drug-naïve and prodromal individuals.
+- The gut–brain axis is a biologically plausible and partly experimentally supported route for disease initiation/propagation in at least a subset of patients.
+- The microbiome is a credible source of **biomarkers** (for early/risk detection) and **therapeutic targets**.
+
+**Key limitations:**
+- Most human evidence is **associational**, not causal. Mendelian randomization and animal models help, but causality in humans remains unproven.
+- **Population and methodological heterogeneity** — exact taxa differ across cohorts, diets, geographies, and sequencing methods, complicating a universal "PD microbiome."
+- **Confounders** — PD medications, constipation itself, and diet all reshape the microbiome.
+- No microbiome intervention is yet proven to be **disease-modifying** (to slow neurodegeneration rather than ease symptoms); trials are small and short.
+
+**Outlook:** The field is moving from cataloguing *who* is present toward *what they do* (metagenomic function, metabolites) and toward intervention. Active directions include TyrDC inhibitors to protect levodopa, targeted reduction of *Desulfovibrio* and pro-inflammatory taxa, next-generation defined bacterial consortia, and larger, longer FMT trials to test whether early intervention can bend the disease curve ([*Frontiers in Nutrition*, 2024](https://www.frontiersin.org/journals/nutrition/articles/10.3389/fnut.2024.1496616/full); [*Future Neurology* / Taylor & Francis, 2025](https://www.tandfonline.com/doi/full/10.1080/14796708.2025.2494981)).
+
+---
+
+## Sources
+
+1. Wallen ZD et al. *Metagenomics of Parkinson's disease implicates the gut microbiome in multiple disease mechanisms.* **Nature Communications** (2022). https://www.ncbi.nlm.nih.gov/pmc/articles/PMC9663292/
+2. Boktor JC et al. *Integrated Multi-Cohort Analysis of the Parkinson's Disease Gut Metagenome.* **Movement Disorders** (2023). https://movementdisorders.onlinelibrary.wiley.com/doi/10.1002/mds.29300
+3. Palacios N et al. *Metagenomics of the Gut Microbiome in Parkinson's Disease: Prodromal Changes.* **Annals of Neurology** (2023). https://onlinelibrary.wiley.com/doi/10.1002/ana.26719
+4. Bruggeman A et al. *Safety and efficacy of faecal microbiota transplantation in mild-to-moderate Parkinson's disease (GUT-PARFECT): phase 2 RCT.* **eClinicalMedicine** (2024). https://www.thelancet.com/journals/eclinm/article/PIIS2589-5370(24)00142-1/fulltext
+5. Scheperjans F et al. *Fecal Microbiota Transplantation for Treatment of Parkinson Disease: A Randomized Clinical Trial.* **JAMA Neurology** (2024). https://jamanetwork.com/journals/jamaneurology/fullarticle/2821254
+6. DuPont HL et al. *FMT in Parkinson's disease — randomized repeat-dose, placebo-controlled pilot.* **Frontiers in Neurology** (2023). https://www.frontiersin.org/journals/neurology/articles/10.3389/fneur.2023.1104759/full
+7. Maini Rekdal V et al. *Discovery and inhibition of an interspecies gut bacterial pathway for levodopa metabolism.* **Science** (2019). https://www.science.org/doi/10.1126/science.aau6323
+8. van Kessel SP et al. *Gut bacterial tyrosine decarboxylases restrict levels of levodopa.* **Nature Communications** (2019). https://www.nature.com/articles/s41467-019-08294-y
+9. *Association of Enterococcus faecalis and tyrosine decarboxylase gene levels with levodopa pharmacokinetics in PD.* **npj Parkinson's Disease** (2025). https://www.nature.com/articles/s41531-025-00903-6
+10. *Strain-specific effects of Desulfovibrio on neurodegeneration and oxidative stress in a C. elegans PD model.* **npj Parkinson's Disease** (2025). https://www.nature.com/articles/s41531-025-01102-z
+11. *Gut-microbiome-brain axis: crosstalk between the vagus nerve, alpha-synuclein and the brain in PD.* **Neural Regeneration Research** (2023). https://pmc.ncbi.nlm.nih.gov/articles/PMC10358673/
+12. *Gut mucosal cells transfer α-synuclein to the vagus nerve.* **JCI Insight** (2023). https://insight.jci.org/articles/view/172192
+13. *The Gut Microbiome as a Catalyst and Emerging Therapeutic Target for PD: A Comprehensive Update.* **Biomedicines / MDPI** (2024). https://www.mdpi.com/2227-9059/12/8/1738
+14. *Gut Microbiome and Its Role in Parkinson's Disease.* **PMC review** (2024). https://pmc.ncbi.nlm.nih.gov/articles/PMC11624045/
+15. *Effect of probiotic supplementation on GI motility, inflammation, motor and non-motor symptoms in PD: meta-analysis of RCTs.* (2023). https://www.ncbi.nlm.nih.gov/pmc/articles/PMC9990363/
+16. Leta V et al. *Effects of a Four-Strain Probiotic on Gut Microbiota, Inflammation, and Symptoms in PD: RCT.* **Movement Disorders** (2025). https://movementdisorders.onlinelibrary.wiley.com/doi/10.1002/mds.70047
+17. *Exploring Braak's Hypothesis of Parkinson's Disease.* **PMC** (2017). https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5304413/
+18. *Microbiome-based therapies for Parkinson's disease.* **Frontiers in Nutrition** (2024). https://www.frontiersin.org/journals/nutrition/articles/10.3389/fnut.2024.1496616/full
+
+---
+
+*Note: This report synthesizes peer-reviewed literature current to mid-2026. The gut–microbiome link in PD is an area of active, fast-moving research; findings — especially on therapeutic efficacy — should be considered provisional pending larger, longer randomized trials. This is a research summary, not medical advice.*
+
+## Citations
+
+1. https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5304413/
+2. https://insight.jci.org/articles/view/172192
+3. https://pmc.ncbi.nlm.nih.gov/articles/PMC10358673/
+4. https://www.ncbi.nlm.nih.gov/pmc/articles/PMC12320529/
+5. https://www.ncbi.nlm.nih.gov/pmc/articles/PMC9663292/
+6. https://movementdisorders.onlinelibrary.wiley.com/doi/10.1002/mds.29300
+7. https://onlinelibrary.wiley.com/doi/10.1002/ana.26719
+8. https://www.mdpi.com/2227-9059/12/8/1738
+9. https://pmc.ncbi.nlm.nih.gov/articles/PMC11624045/
+10. https://www.nature.com/articles/s41531-025-01102-z
+11. https://pmc.ncbi.nlm.nih.gov/articles/PMC12134241/
+12. https://www.science.org/doi/10.1126/science.aau6323
+13. https://www.nature.com/articles/s41467-019-08294-y
+14. https://www.nature.com/articles/s41531-025-00903-6
+15. https://www.thelancet.com/journals/eclinm/article/PIIS2589-5370(24
+16. https://jamanetwork.com/journals/jamaneurology/fullarticle/2821254
+17. https://www.frontiersin.org/journals/neurology/articles/10.3389/fneur.2023.1104759/full
+18. https://journals.sagepub.com/doi/10.3233/JPD-249007
+19. https://www.ncbi.nlm.nih.gov/pmc/articles/PMC9990363/
+20. https://pmc.ncbi.nlm.nih.gov/articles/PMC10728848/
+21. https://movementdisorders.onlinelibrary.wiley.com/doi/10.1002/mds.70047
+22. https://journals.sagepub.com/doi/10.3233/JPD-240172
+23. https://www.frontiersin.org/journals/nutrition/articles/10.3389/fnut.2024.1496616/full
+24. https://www.tandfonline.com/doi/full/10.1080/14796708.2025.2494981

--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -363,8 +363,22 @@ In non-interactive mode the run is driven by an agent, and
   **makes `allowed_tools` a no-op** (all tools become available). Only enable it
   in trusted, sandboxed environments.
 
-Widen `allowed_tools` if a task genuinely needs more (e.g. reading local files
-in an `add_dirs` path).
+Widen `allowed_tools` if a task genuinely needs more. The most common case is
+**research over local documents**: the default set is web-only and deliberately
+omits the `Read` tool, so to let Claude Code read files you have supplied (for
+example in an `add_dirs` path) you must add it explicitly:
+
+```python
+params = ClaudeCodeParams(
+    allowed_tools=["WebSearch", "WebFetch", "Read"],
+    add_dirs=["/data/papers"],
+)
+```
+
+`Read` is left out of the default because it grants the agent read access to the
+local filesystem, which is unnecessary for purely web-based research and is a
+mild information-disclosure surface if the query is untrusted. Add it only when
+reading local documents is actually part of the task.
 
 ### Usage
 

--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -338,16 +338,33 @@ from deep_research_client.provider_params import ClaudeCodeParams
 
 params = ClaudeCodeParams(
     model="opus",                 # optional; forwarded to `claude --model`
-    skip_permissions=True,        # adds --dangerously-skip-permissions (default)
-    allowed_tools=["WebSearch", "WebFetch"],  # optional --allowedTools allowlist
+    allowed_tools=["WebSearch", "WebFetch"],  # tool allowlist (default: read-only research set)
+    skip_permissions=False,       # default; True bypasses ALL checks (see Security)
     add_dirs=["/data/papers"],    # optional --add-dir entries
     working_dir="/tmp/research",  # optional cwd for the run
     extra_args=["--max-turns", "30"],  # escape hatch for unmodeled flags
 )
 ```
 
-When `skip_permissions` is `False`, you can instead set `permission_mode` (e.g.
-`"plan"` or `"acceptEdits"`).
+When `skip_permissions` is `False` (the default), you can also set
+`permission_mode` (e.g. `"plan"` or `"acceptEdits"`).
+
+### Security
+
+In non-interactive mode the run is driven by an agent, and
+`get_first_available()` may select this provider for an arbitrary query whenever
+`claude` is on PATH. To keep that safe by default:
+
+- `allowed_tools` defaults to a **read-only research set** (`["WebSearch", "WebFetch"]`),
+  passed via `--allowedTools`. Tools not on the list are auto-denied (without
+  blocking the run), so the agent cannot edit files or run shell commands.
+- `skip_permissions` defaults to **`False`**. Setting it `True` adds
+  `--dangerously-skip-permissions`, which bypasses every permission check and
+  **makes `allowed_tools` a no-op** (all tools become available). Only enable it
+  in trusted, sandboxed environments.
+
+Widen `allowed_tools` if a task genuinely needs more (e.g. reading local files
+in an `add_dirs` path).
 
 ### Usage
 
@@ -369,8 +386,8 @@ actual model(s) used and run provenance (`run_metadata`).
 ### Limitations
 
 - Requires the `claude` CLI installed and authenticated locally
-- Runs non-interactively, typically with `--dangerously-skip-permissions`
-  (recommended only in trusted/sandboxed environments)
+- Restricted to a read-only research toolset by default; broaden `allowed_tools`
+  (or enable `skip_permissions` in a sandbox) for tasks that need more
 - Non-deterministic results
 
 ---

--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -13,6 +13,7 @@ Complete reference for all supported research providers.
 | Consensus | `CONSENSUS_API_KEY` | Academic papers | Fast |
 | OpenScientist | `OPENSCIENTIST_API_KEY` | Autonomous research, PMID citations | Very slow |
 | Cyberian | (local agents) | Agent-based, thorough | Very slow |
+| Claude Code | (local `claude` CLI) | Agentic web research, no API key | Slow |
 
 ## OpenAI Deep Research
 
@@ -307,6 +308,70 @@ This is useful for:
 - **Testing**: Run a quick verification without full research
 - **Cost control**: Limit agent API calls
 - **Debugging**: Inspect intermediate results after fixed iterations
+
+---
+
+## Claude Code
+
+Claude Code is a local command-line tool rather than an HTTP API. This provider
+shells out to the `claude` binary in non-interactive ("print") mode, pipes the
+research prompt to it via stdin, and lets Claude Code's own agentic tools (web
+search, web fetch, file reading) carry out the research. The final answer comes
+back as a cited markdown report.
+
+### Setup
+
+No API key is needed — authentication and billing are handled by your local
+Claude Code installation. Just make sure the CLI is installed and on your PATH:
+
+```bash
+claude --version   # should succeed
+```
+
+The provider is auto-detected whenever `claude` is found on PATH. Set
+`DISABLE_CLAUDE_CODE_PROVIDER=true` to opt out of auto-detection.
+
+### Parameters
+
+```python
+from deep_research_client.provider_params import ClaudeCodeParams
+
+params = ClaudeCodeParams(
+    model="opus",                 # optional; forwarded to `claude --model`
+    skip_permissions=True,        # adds --dangerously-skip-permissions (default)
+    allowed_tools=["WebSearch", "WebFetch"],  # optional --allowedTools allowlist
+    add_dirs=["/data/papers"],    # optional --add-dir entries
+    working_dir="/tmp/research",  # optional cwd for the run
+    extra_args=["--max-turns", "30"],  # escape hatch for unmodeled flags
+)
+```
+
+When `skip_permissions` is `False`, you can instead set `permission_mode` (e.g.
+`"plan"` or `"acceptEdits"`).
+
+### Usage
+
+```bash
+deep-research-client research --provider claude_code "your research question"
+```
+
+See [a full example report](../examples/claude-code-deep-research-example.md)
+produced by this provider, including the YAML frontmatter that records the
+actual model(s) used and run provenance (`run_metadata`).
+
+### Characteristics
+
+- **Cost**: Handled by your Claude Code subscription / API key
+- **Speed**: Slow (agentic, multi-step)
+- **Capabilities**: Web search, citation tracking, code interpretation
+- **Auth**: None required by this client; relies on local Claude Code
+
+### Limitations
+
+- Requires the `claude` CLI installed and authenticated locally
+- Runs non-interactively, typically with `--dangerously-skip-permissions`
+  (recommended only in trusted/sandboxed environments)
+- Non-deterministic results
 
 ---
 

--- a/src/deep_research_client/cli.py
+++ b/src/deep_research_client/cli.py
@@ -36,6 +36,7 @@ PROVIDER_CREDENTIAL_HINTS = {
     "perplexity": ("PERPLEXITY_API_KEY", "Perplexity AI"),
     "consensus": ("CONSENSUS_API_KEY", "Consensus"),
     "openscientist": ("OPENSCIENTIST_API_KEY", "OpenScientist"),
+    "claude_code": ("the `claude` CLI on PATH", "Claude Code"),
     "mock": ("ENABLE_MOCK_PROVIDER=true", "Mock provider"),
 }
 
@@ -244,7 +245,7 @@ def research(
     query: Annotated[Optional[str], typer.Argument(
         help="Research query or question (not needed if using --template)")] = None,
     provider: Annotated[Optional[str], typer.Option(
-        help="Specific provider to use (openai, falcon, asta, perplexity, consensus, openscientist, mock)")] = None,
+        help="Specific provider to use (openai, falcon, asta, perplexity, consensus, openscientist, claude_code, mock)")] = None,
     model: Annotated[Optional[str], typer.Option(
         help="Model to use for the provider (overrides provider default)")] = None,
     output: Annotated[Optional[Path], typer.Option(

--- a/src/deep_research_client/client.py
+++ b/src/deep_research_client/client.py
@@ -20,6 +20,7 @@ PROVIDER_CLASS_PATHS: dict[str, tuple[str, str]] = {
     "consensus": ("deep_research_client.providers.consensus", "ConsensusProvider"),
     "cyberian": ("deep_research_client.providers.cyberian", "CyberianProvider"),
     "openscientist": ("deep_research_client.providers.openscientist", "OpenScientistProvider"),
+    "claude_code": ("deep_research_client.providers.claude_code", "ClaudeCodeProvider"),
     "mock": ("deep_research_client.providers.mock", "MockProvider"),
 }
 
@@ -137,6 +138,22 @@ class DeepResearchClient:
         except ImportError:
             pass  # Cyberian not installed, skip
 
+        # Claude Code provider - available whenever the `claude` CLI is on PATH.
+        # No API key required; auth/billing is handled by the local installation.
+        # Set DISABLE_CLAUDE_CODE_PROVIDER=true to opt out of auto-detection.
+        import shutil
+        if (
+            os.getenv("DISABLE_CLAUDE_CODE_PROVIDER", "").lower() not in ("true", "1", "yes")
+            and shutil.which("claude") is not None
+        ):
+            claude_code_config = ProviderConfig(
+                name="claude_code",
+                api_key=None,  # Not required for Claude Code
+                enabled=True,
+                timeout=1800,  # 30 minutes for long-running agentic research
+            )
+            self.registry.register(self._create_provider("claude_code", claude_code_config))
+
         # Mock provider only if explicitly requested via environment
         if os.getenv("ENABLE_MOCK_PROVIDER", "").lower() in ("true", "1", "yes"):
             mock_config = ProviderConfig(
@@ -212,6 +229,11 @@ class DeepResearchClient:
             effective_params["_cache_version"] = "snippet-v5"
         elif research_provider.name in {"falcon", "openscientist"}:
             effective_params["_cache_version"] = "artifacts-v1"
+        # The Claude Code prompt scaffolding (inline-report directive) and run
+        # provenance capture changed how results are produced; bump to keep
+        # stale cache entries from shadowing current live results.
+        elif research_provider.name == "claude_code":
+            effective_params["_cache_version"] = "inline-report-v1"
 
         return effective_params or None
 
@@ -319,8 +341,11 @@ class DeepResearchClient:
                     contributors=metadata.get('contributors', [])
                 )
 
-        # Add provider configuration
-        result.model = getattr(research_provider, 'model', None)
+        # Add provider configuration. Prefer a model the provider already recorded
+        # on the result (e.g. the actual model id reported by the run) over the
+        # provider's configured/default model.
+        if result.model is None:
+            result.model = getattr(research_provider, 'model', None)
         result.provider_config = {
             'timeout': research_provider.config.timeout,
             'max_retries': research_provider.config.max_retries,

--- a/src/deep_research_client/client.py
+++ b/src/deep_research_client/client.py
@@ -141,6 +141,12 @@ class DeepResearchClient:
         # Claude Code provider - available whenever the `claude` CLI is on PATH.
         # No API key required; auth/billing is handled by the local installation.
         # Set DISABLE_CLAUDE_CODE_PROVIDER=true to opt out of auto-detection.
+        #
+        # NOTE: auto-detection deliberately probes the default "claude" executable
+        # rather than constructing the provider and calling is_available(), to keep
+        # env setup import-light. A custom claude_executable (a ClaudeCodeParams
+        # field, not env-derived) is therefore not honored here; pass an explicit
+        # provider_config to register the provider against a non-default binary.
         import shutil
         if (
             os.getenv("DISABLE_CLAUDE_CODE_PROVIDER", "").lower() not in ("true", "1", "yes")

--- a/src/deep_research_client/formatter.py
+++ b/src/deep_research_client/formatter.py
@@ -52,6 +52,10 @@ class ResultFormatter:
             if trajectory_id:
                 metadata["trajectory_id"] = trajectory_id
 
+        # Add run provenance metadata (e.g. actual model(s) used, cost, turns)
+        if result.run_metadata:
+            metadata["run_metadata"] = result.run_metadata
+
         # Add citation count
         if result.citations:
             metadata["citation_count"] = len(result.citations)

--- a/src/deep_research_client/model_cards.py
+++ b/src/deep_research_client/model_cards.py
@@ -496,6 +496,51 @@ def create_openscientist_model_cards() -> ProviderModelCards:
     )
 
 
+def create_claude_code_model_cards() -> ProviderModelCards:
+    """Create model cards for the Claude Code research provider."""
+
+    default = ModelCard(
+        name="claude-code-default",
+        display_name="Claude Code (account default model)",
+        description=(
+            "Runs the local Claude Code CLI in non-interactive mode, letting its "
+            "agentic tools (web search, web fetch, file reading) drive a multi-step "
+            "research process that yields a cited markdown report. Uses whichever "
+            "model the local Claude Code installation defaults to."
+        ),
+        cost_level=CostLevel.MEDIUM,
+        time_estimate=TimeEstimate.SLOW,
+        capabilities=[
+            ModelCapability.WEB_SEARCH,
+            ModelCapability.CITATION_TRACKING,
+            ModelCapability.CODE_INTERPRETATION,
+        ],
+        aliases=["claude", "claude-code", "cc", "default"],
+        pricing_notes=(
+            "Billing is handled by the local Claude Code installation (subscription "
+            "or Anthropic API key); no separate provider API key is required."
+        ),
+        use_cases=[
+            "Deep research using an already-configured Claude Code environment",
+            "Agentic web research with citations",
+            "Research in environments where curation already runs Claude Code",
+        ],
+        limitations=[
+            "Requires the `claude` CLI to be installed and authenticated locally",
+            "Runs non-interactively, typically with --dangerously-skip-permissions",
+            "Non-deterministic results",
+        ],
+    )
+
+    return ProviderModelCards(
+        provider_name="claude_code",
+        default_model="claude-code-default",
+        models={
+            "claude-code-default": default,
+        },
+    )
+
+
 # Registry of all provider model cards
 PROVIDER_MODEL_CARDS: Dict[str, ProviderModelCards] = {
     "openai": create_openai_model_cards(),
@@ -504,6 +549,7 @@ PROVIDER_MODEL_CARDS: Dict[str, ProviderModelCards] = {
     "asta": create_asta_model_cards(),
     "consensus": create_consensus_model_cards(),
     "openscientist": create_openscientist_model_cards(),
+    "claude_code": create_claude_code_model_cards(),
 }
 
 

--- a/src/deep_research_client/model_cards.py
+++ b/src/deep_research_client/model_cards.py
@@ -527,7 +527,7 @@ def create_claude_code_model_cards() -> ProviderModelCards:
         ],
         limitations=[
             "Requires the `claude` CLI to be installed and authenticated locally",
-            "Runs non-interactively, typically with --dangerously-skip-permissions",
+            "Restricted to a read-only research toolset by default (web search/fetch)",
             "Non-deterministic results",
         ],
     )

--- a/src/deep_research_client/models.py
+++ b/src/deep_research_client/models.py
@@ -98,6 +98,14 @@ class ResearchResult(BaseModel):
     # Provider configuration
     model: Optional[str] = Field(default=None, description="Model used by provider")
     provider_config: Optional[Dict[str, Any]] = Field(default=None, description="Provider configuration")
+    run_metadata: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description=(
+            "Provider-reported provenance about the actual run (e.g. model(s) used, "
+            "token/cost usage, number of turns). Distinct from the requested "
+            "configuration in provider_config."
+        ),
+    )
 
 
 class ProviderConfig(BaseModel):

--- a/src/deep_research_client/processing/result_formatter.py
+++ b/src/deep_research_client/processing/result_formatter.py
@@ -66,6 +66,10 @@ class ResultFormatter:
             if trajectory_id:
                 metadata["trajectory_id"] = trajectory_id
 
+        # Add run provenance metadata (e.g. actual model(s) used, cost, turns)
+        if result.run_metadata:
+            metadata["run_metadata"] = result.run_metadata
+
         # Add citation count
         if result.citations:
             metadata["citation_count"] = len(result.citations)

--- a/src/deep_research_client/provider_params.py
+++ b/src/deep_research_client/provider_params.py
@@ -340,6 +340,58 @@ class CyberianParams(BaseProviderParams):
     )
 
 
+class ClaudeCodeParams(BaseProviderParams):
+    """Parameters specific to the Claude Code research provider.
+
+    Claude Code is invoked as a local command-line tool (the ``claude`` binary)
+    rather than via an HTTP API. The provider shells out to it in
+    non-interactive "print" mode and lets Claude Code use its own agentic tools
+    (web search, file reading, etc.) to perform the research.
+    """
+
+    claude_executable: str = Field(
+        default="claude",
+        description="Path or name of the Claude Code executable to invoke"
+    )
+    skip_permissions: bool = Field(
+        default=True,
+        description=(
+            "Pass --dangerously-skip-permissions so the non-interactive run does "
+            "not block on permission prompts. Recommended only in trusted/sandboxed "
+            "environments."
+        )
+    )
+    allowed_tools: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Optional allowlist of Claude Code tool names (e.g. ['WebSearch', "
+            "'WebFetch']) passed via --allowedTools. Leave empty to allow all tools."
+        )
+    )
+    permission_mode: Optional[str] = Field(
+        default=None,
+        description=(
+            "Optional Claude Code --permission-mode value (e.g. 'plan', "
+            "'acceptEdits'). Ignored when skip_permissions is true."
+        )
+    )
+    add_dirs: List[str] = Field(
+        default_factory=list,
+        description="Additional directories to grant Claude Code tool access to (--add-dir)"
+    )
+    working_dir: Optional[str] = Field(
+        default=None,
+        description="Working directory in which to run the claude process (defaults to current dir)"
+    )
+    extra_args: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Extra command-line arguments appended verbatim to the claude invocation. "
+            "Escape hatch for flags not otherwise modeled (e.g. ['--max-turns', '20'])."
+        )
+    )
+
+
 # Registry mapping provider names to their parameter models
 PROVIDER_PARAMS_REGISTRY: dict[str, Type[BaseProviderParams]] = {
     "perplexity": PerplexityParams,
@@ -350,6 +402,7 @@ PROVIDER_PARAMS_REGISTRY: dict[str, Type[BaseProviderParams]] = {
     "mock": MockParams,
     "cyberian": CyberianParams,
     "openscientist": OpenScientistParams,
+    "claude_code": ClaudeCodeParams,
 }
 
 

--- a/src/deep_research_client/provider_params.py
+++ b/src/deep_research_client/provider_params.py
@@ -354,18 +354,28 @@ class ClaudeCodeParams(BaseProviderParams):
         description="Path or name of the Claude Code executable to invoke"
     )
     skip_permissions: bool = Field(
-        default=True,
+        default=False,
         description=(
-            "Pass --dangerously-skip-permissions so the non-interactive run does "
-            "not block on permission prompts. Recommended only in trusted/sandboxed "
-            "environments."
+            "Pass --dangerously-skip-permissions, which bypasses ALL permission "
+            "checks and lets the agent use every tool (file edits, shell, etc.). "
+            "SECURITY: this overrides allowed_tools entirely, so the allowlist no "
+            "longer restricts anything. Defaults to False so the read-only "
+            "allowed_tools allowlist governs tool access. Enable only in trusted, "
+            "sandboxed environments where running arbitrary tools on an "
+            "agent-driven (possibly untrusted) query is acceptable."
         )
     )
     allowed_tools: List[str] = Field(
-        default_factory=list,
+        default_factory=lambda: ["WebSearch", "WebFetch"],
         description=(
-            "Optional allowlist of Claude Code tool names (e.g. ['WebSearch', "
-            "'WebFetch']) passed via --allowedTools. Leave empty to allow all tools."
+            "Allowlist of Claude Code tool names passed via --allowedTools. In "
+            "non-interactive mode, tools not on this list are auto-denied (without "
+            "blocking), so this is the primary tool-authority control. Defaults to "
+            "a read-only research set (WebSearch, WebFetch) so the out-of-the-box "
+            "behavior cannot mutate the filesystem or run shell commands even on an "
+            "untrusted query. Widen it for tasks that need more, or set it empty "
+            "AND skip_permissions=True to allow all tools. Has no effect when "
+            "skip_permissions is True."
         )
     )
     permission_mode: Optional[str] = Field(
@@ -382,6 +392,14 @@ class ClaudeCodeParams(BaseProviderParams):
     working_dir: Optional[str] = Field(
         default=None,
         description="Working directory in which to run the claude process (defaults to current dir)"
+    )
+    timeout: int = Field(
+        default=1800,
+        ge=1,
+        description=(
+            "Maximum seconds to wait for the claude run before killing it. "
+            "Overridden by ProviderConfig.timeout when that is set."
+        )
     )
     extra_args: List[str] = Field(
         default_factory=list,

--- a/src/deep_research_client/providers/claude_code.py
+++ b/src/deep_research_client/providers/claude_code.py
@@ -6,10 +6,17 @@ piping the research prompt to it and letting Claude Code's own agentic tools
 (web search, web fetch, file reading, etc.) carry out a multi-step research
 workflow. The final answer is returned as a cited markdown report.
 
-Because the run is non-interactive, it typically needs
-``--dangerously-skip-permissions`` so it does not block on permission prompts.
 No provider API key is required: billing and authentication are handled by the
 local Claude Code installation.
+
+Security: by default the provider does NOT pass ``--dangerously-skip-permissions``.
+Instead it restricts the agent to a read-only research toolset
+(``allowed_tools`` defaults to WebSearch + WebFetch) via ``--allowedTools``; in
+non-interactive mode any tool not on that list is auto-denied without blocking.
+This keeps the out-of-the-box behavior from mutating the filesystem or running
+shell commands even on an untrusted query. Enabling ``skip_permissions`` bypasses
+all permission checks and makes the allowlist a no-op, so it should only be used
+in trusted, sandboxed environments.
 """
 
 import asyncio
@@ -27,10 +34,6 @@ from ..model_cards import ProviderModelCards, create_claude_code_model_cards
 from ..system_prompts import DEFAULT_RESEARCH_SYSTEM_PROMPT
 
 logger = logging.getLogger(__name__)
-
-# Deep research with an agentic CLI workflow can take a long time; default to
-# 30 minutes, matching the other long-running agent-based providers.
-CLAUDE_CODE_DEFAULT_TIMEOUT = 1800
 
 # Non-interactive ("print") mode has no "later": the process emits one response
 # and exits. Local skills/workflows that defer work to a background task would be
@@ -74,7 +77,8 @@ class ClaudeCodeProvider(ResearchProvider):
         super().__init__(config, self.params.model)
 
         self.claude_executable = self.params.claude_executable
-        self.timeout = config.timeout or CLAUDE_CODE_DEFAULT_TIMEOUT
+        # ProviderConfig.timeout wins when set; otherwise use the params default.
+        self.timeout = config.timeout or self.params.timeout
 
         logger.debug(
             "Initializing Claude Code provider (executable=%s, skip_permissions=%s)",
@@ -316,22 +320,6 @@ class ClaudeCodeProvider(ResearchProvider):
         if not result or not str(result).strip():
             raise ValueError("Claude Code output contained no result text.")
         return str(result)
-
-    @classmethod
-    def _parse_output(cls, stdout: str) -> str:
-        """Extract the markdown report from Claude Code's JSON output.
-
-        Args:
-            stdout: Raw stdout from ``claude --print --output-format json``.
-
-        Returns:
-            The markdown research report.
-
-        Raises:
-            ValueError: If the output is not valid JSON, reports an error, or
-                contains no result text.
-        """
-        return cls._result_text(cls._load_payload(stdout))
 
     @staticmethod
     def _extract_run_metadata(data: dict) -> dict:

--- a/src/deep_research_client/providers/claude_code.py
+++ b/src/deep_research_client/providers/claude_code.py
@@ -1,0 +1,393 @@
+"""Claude Code research provider.
+
+Unlike the API-based providers, Claude Code is a local command-line tool (the
+``claude`` binary). This provider drives it in non-interactive "print" mode,
+piping the research prompt to it and letting Claude Code's own agentic tools
+(web search, web fetch, file reading, etc.) carry out a multi-step research
+workflow. The final answer is returned as a cited markdown report.
+
+Because the run is non-interactive, it typically needs
+``--dangerously-skip-permissions`` so it does not block on permission prompts.
+No provider API key is required: billing and authentication are handled by the
+local Claude Code installation.
+"""
+
+import asyncio
+import json
+import logging
+import re
+import shutil
+from datetime import datetime
+from typing import List, Optional
+
+from . import ResearchProvider
+from ..models import ResearchResult, ProviderConfig
+from ..provider_params import ClaudeCodeParams
+from ..model_cards import ProviderModelCards, create_claude_code_model_cards
+from ..system_prompts import DEFAULT_RESEARCH_SYSTEM_PROMPT
+
+logger = logging.getLogger(__name__)
+
+# Deep research with an agentic CLI workflow can take a long time; default to
+# 30 minutes, matching the other long-running agent-based providers.
+CLAUDE_CODE_DEFAULT_TIMEOUT = 1800
+
+# Non-interactive ("print") mode has no "later": the process emits one response
+# and exits. Local skills/workflows that defer work to a background task would be
+# orphaned, leaving us with only a chatty preamble instead of a report. This
+# directive forces Claude Code to do the work and emit the finished report inline.
+_INLINE_REPORT_DIRECTIVE = (
+    "IMPORTANT: You are running non-interactively and must produce the complete "
+    "final research report directly in this single response. Do the research now "
+    "using your available tools (web search, web fetch, etc.) and write the full "
+    "report inline. Do NOT defer the work, do NOT hand it off to a background task, "
+    "workflow, or sub-agent, do NOT promise to follow up later, and do NOT ask "
+    "clarifying questions. Output only the report itself in Markdown."
+)
+
+# Aliases that point at the provider's own default model card rather than a real
+# Claude model id. When the user "selects" one of these we let the local Claude
+# Code installation pick its own default model instead of forwarding --model.
+_DEFAULT_MODEL_SENTINELS = {
+    "claude-code-default",
+    "claude-code",
+    "claude",
+    "cc",
+    "default",
+}
+
+# URL pattern for citation extraction (mirrors the other providers).
+_URL_PATTERN = re.compile(r"https?://[^\s\)\]>]+")
+
+
+class ClaudeCodeProvider(ResearchProvider):
+    """Provider that runs the local Claude Code CLI to perform research."""
+
+    def __init__(self, config: ProviderConfig, params: Optional[ClaudeCodeParams] = None):
+        """Initialize the Claude Code provider.
+
+        Args:
+            config: Provider configuration (no API key required).
+            params: Claude Code-specific parameters.
+        """
+        self.params = params or ClaudeCodeParams()
+        super().__init__(config, self.params.model)
+
+        self.claude_executable = self.params.claude_executable
+        self.timeout = config.timeout or CLAUDE_CODE_DEFAULT_TIMEOUT
+
+        logger.debug(
+            "Initializing Claude Code provider (executable=%s, skip_permissions=%s)",
+            self.claude_executable,
+            self.params.skip_permissions,
+        )
+
+    def get_default_model(self) -> str:
+        """Get the default model identifier for this provider."""
+        return "claude-code-default"
+
+    @classmethod
+    def model_cards(cls) -> ProviderModelCards:
+        """Get model cards for the Claude Code provider."""
+        return create_claude_code_model_cards()
+
+    def is_available(self) -> bool:
+        """Check whether the Claude Code CLI is available.
+
+        Returns:
+            True if the provider is enabled and the ``claude`` executable is
+            resolvable on the PATH (or as an absolute path).
+        """
+        if not self.config.enabled:
+            return False
+
+        if shutil.which(self.claude_executable) is None:
+            logger.warning(
+                "Claude Code executable %r not found in PATH", self.claude_executable
+            )
+            return False
+
+        return True
+
+    def _resolve_cli_model(self) -> Optional[str]:
+        """Resolve the raw ``--model`` value to forward to the CLI, if any.
+
+        We forward the user's raw model string (e.g. ``opus`` or a full model
+        id) rather than the resolved model-card name. Provider-internal default
+        aliases resolve to ``None`` so the local Claude Code installation picks
+        its own default model.
+        """
+        raw_model = self.params.model
+        if not raw_model:
+            return None
+        if raw_model.strip().lower() in _DEFAULT_MODEL_SENTINELS:
+            return None
+        return raw_model
+
+    def _build_command(self) -> List[str]:
+        """Build the ``claude`` command-line invocation (without the prompt).
+
+        The research prompt is supplied separately via stdin, so it does not
+        appear here. This method is pure and side-effect free to keep it easy to
+        unit test.
+
+        Returns:
+            The argument list to pass to ``asyncio.create_subprocess_exec``.
+        """
+        command: List[str] = [
+            self.claude_executable,
+            "--print",
+            "--output-format",
+            "json",
+        ]
+
+        if self.params.skip_permissions:
+            command.append("--dangerously-skip-permissions")
+        elif self.params.permission_mode:
+            command.extend(["--permission-mode", self.params.permission_mode])
+
+        cli_model = self._resolve_cli_model()
+        if cli_model:
+            command.extend(["--model", cli_model])
+
+        system_prompt = self.params.system_prompt or DEFAULT_RESEARCH_SYSTEM_PROMPT
+        # Always append the inline-report directive so print-mode runs produce the
+        # report directly rather than deferring to a background workflow.
+        system_prompt = f"{system_prompt}\n\n{_INLINE_REPORT_DIRECTIVE}"
+        command.extend(["--append-system-prompt", system_prompt])
+
+        if self.params.allowed_tools:
+            command.extend(["--allowedTools", ",".join(self.params.allowed_tools)])
+
+        for directory in self.params.add_dirs:
+            command.extend(["--add-dir", directory])
+
+        command.extend(self.params.extra_args)
+
+        return command
+
+    async def research(self, query: str) -> ResearchResult:
+        """Perform research by running the Claude Code CLI.
+
+        Args:
+            query: The research question or topic.
+
+        Returns:
+            ResearchResult with the markdown report and extracted citations.
+
+        Raises:
+            ValueError: If the provider is unavailable, the query is empty, or
+                the Claude Code run fails.
+        """
+        start_time = datetime.now()
+
+        if not self.is_available():
+            raise ValueError(
+                "Claude Code provider not available. Ensure the 'claude' CLI is "
+                "installed and on your PATH."
+            )
+
+        if not query or not query.strip():
+            raise ValueError("Research query must not be empty.")
+
+        command = self._build_command()
+        logger.info("Running Claude Code research (timeout=%ss)", self.timeout)
+        logger.debug("Claude Code command: %s", " ".join(command))
+
+        stdout, stderr, returncode = await self._run_process(command, query)
+
+        if returncode != 0:
+            raise ValueError(
+                f"Claude Code exited with code {returncode}: "
+                f"{stderr.strip() or '<no stderr>'}"
+            )
+
+        data = self._load_payload(stdout)
+        markdown = self._result_text(data)
+        run_metadata = self._extract_run_metadata(data)
+        citations = self._extract_citations(markdown)
+
+        # Prefer the model id(s) the run actually reported over our sentinel
+        # default, so provenance reflects what really ran (even if unspecified or
+        # switched mid-flight).
+        models_used = run_metadata.get("models_used")
+        model_label = ", ".join(models_used) if models_used else self.model
+
+        end_time = datetime.now()
+        duration = (end_time - start_time).total_seconds()
+        logger.info(
+            "Claude Code research completed in %.1fs (%d chars, %d citations, model=%s)",
+            duration,
+            len(markdown),
+            len(citations),
+            model_label,
+        )
+
+        return ResearchResult(
+            markdown=markdown,
+            citations=citations,
+            provider=self.name,
+            query=query,
+            model=model_label,
+            run_metadata=run_metadata or None,
+            start_time=start_time,
+            end_time=end_time,
+            duration_seconds=duration,
+        )
+
+    async def _run_process(self, command: List[str], query: str) -> tuple[str, str, int]:
+        """Run the claude subprocess, piping the query to stdin.
+
+        Args:
+            command: The command argument list (without the prompt).
+            query: The research prompt, supplied via stdin.
+
+        Returns:
+            Tuple of (stdout, stderr, return_code).
+
+        Raises:
+            ValueError: If the process does not finish within the timeout.
+        """
+        process = await asyncio.create_subprocess_exec(
+            *command,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=self.params.working_dir,
+        )
+
+        try:
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                process.communicate(input=query.encode("utf-8")),
+                timeout=self.timeout,
+            )
+        except asyncio.TimeoutError:
+            process.kill()
+            await process.wait()
+            raise ValueError(
+                f"Claude Code run timed out after {self.timeout}s."
+            )
+
+        # returncode is set once communicate() has returned.
+        returncode = -1 if process.returncode is None else process.returncode
+        return (
+            stdout_bytes.decode("utf-8", errors="replace"),
+            stderr_bytes.decode("utf-8", errors="replace"),
+            returncode,
+        )
+
+    @staticmethod
+    def _load_payload(stdout: str) -> dict:
+        """Parse and validate Claude Code's JSON output into a dict.
+
+        Args:
+            stdout: Raw stdout from ``claude --print --output-format json``.
+
+        Returns:
+            The parsed JSON payload.
+
+        Raises:
+            ValueError: If the output is empty, not valid JSON, or reports an error.
+        """
+        text = stdout.strip()
+        if not text:
+            raise ValueError("Claude Code returned empty output.")
+
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Could not parse Claude Code JSON output: {exc}")
+
+        if data.get("is_error"):
+            subtype = data.get("subtype", "unknown error")
+            detail = data.get("result") or subtype
+            raise ValueError(f"Claude Code reported an error ({subtype}): {detail}")
+
+        return data
+
+    @staticmethod
+    def _result_text(data: dict) -> str:
+        """Extract the markdown report text from a parsed payload.
+
+        Raises:
+            ValueError: If the payload contains no usable result text.
+        """
+        result = data.get("result")
+        if not result or not str(result).strip():
+            raise ValueError("Claude Code output contained no result text.")
+        return str(result)
+
+    @classmethod
+    def _parse_output(cls, stdout: str) -> str:
+        """Extract the markdown report from Claude Code's JSON output.
+
+        Args:
+            stdout: Raw stdout from ``claude --print --output-format json``.
+
+        Returns:
+            The markdown research report.
+
+        Raises:
+            ValueError: If the output is not valid JSON, reports an error, or
+                contains no result text.
+        """
+        return cls._result_text(cls._load_payload(stdout))
+
+    @staticmethod
+    def _extract_run_metadata(data: dict) -> dict:
+        """Extract run provenance from Claude Code's JSON output.
+
+        The ``modelUsage`` map is keyed by the model id(s) that actually ran, so
+        we can report the real model even when none was requested or it changed
+        mid-flight.
+
+        Args:
+            data: Parsed Claude Code JSON payload.
+
+        Returns:
+            A metadata dict with any of: models_used, num_turns, total_cost_usd,
+            web_search_requests, session_id, stop_reason.
+        """
+        metadata: dict = {}
+
+        model_usage = data.get("modelUsage") or {}
+        models_used = sorted(model_usage.keys())
+        if models_used:
+            metadata["models_used"] = models_used
+
+        web_search = 0
+        for usage in model_usage.values():
+            if isinstance(usage, dict):
+                web_search += usage.get("webSearchRequests") or 0
+        if web_search:
+            metadata["web_search_requests"] = web_search
+
+        if data.get("num_turns") is not None:
+            metadata["num_turns"] = data["num_turns"]
+        if data.get("total_cost_usd") is not None:
+            metadata["total_cost_usd"] = data["total_cost_usd"]
+        if data.get("session_id"):
+            metadata["session_id"] = data["session_id"]
+        if data.get("stop_reason"):
+            metadata["stop_reason"] = data["stop_reason"]
+
+        return metadata
+
+    @staticmethod
+    def _extract_citations(markdown: str) -> List[str]:
+        """Extract URL citations from the markdown report, preserving order.
+
+        Args:
+            markdown: The markdown research report.
+
+        Returns:
+            Deduplicated list of cited URLs.
+        """
+        citations: List[str] = []
+        seen = set()
+        for url in _URL_PATTERN.findall(markdown):
+            cleaned = url.rstrip(".,;")
+            if cleaned and cleaned not in seen:
+                seen.add(cleaned)
+                citations.append(cleaned)
+        return citations

--- a/tests/test_claude_code_provider.py
+++ b/tests/test_claude_code_provider.py
@@ -48,14 +48,17 @@ def test_is_available_false_when_disabled():
 
 
 def test_build_command_defaults():
-    """Default command runs print mode, JSON output, and skips permissions."""
+    """Default command runs print mode, JSON output, and a read-only toolset."""
     provider = make_provider()
     command = provider._build_command()
 
     assert command[0] == "claude"
     assert "--print" in command
     assert command[command.index("--output-format") + 1] == "json"
-    assert "--dangerously-skip-permissions" in command
+    # Secure default: permissions are NOT skipped, and the agent is restricted to
+    # a read-only research toolset via the allowlist.
+    assert "--dangerously-skip-permissions" not in command
+    assert command[command.index("--allowedTools") + 1] == "WebSearch,WebFetch"
     # The research system prompt plus the inline-report directive are appended.
     assert "--append-system-prompt" in command
     appended = command[command.index("--append-system-prompt") + 1]
@@ -63,6 +66,13 @@ def test_build_command_defaults():
     assert _INLINE_REPORT_DIRECTIVE in appended
     # No model is forwarded for the default sentinel.
     assert "--model" not in command
+
+
+def test_build_command_skip_permissions_opt_in():
+    """Opting into skip_permissions adds the dangerous flag (for sandboxes)."""
+    provider = make_provider(ClaudeCodeParams(skip_permissions=True))
+    command = provider._build_command()
+    assert "--dangerously-skip-permissions" in command
 
 
 def test_build_command_forwards_explicit_model():
@@ -116,35 +126,36 @@ def test_build_command_allowed_tools_and_dirs_and_extra_args():
     assert command[-2:] == ["--max-turns", "30"]
 
 
-def test_parse_output_success():
-    """A successful JSON result yields the markdown report."""
+def test_load_payload_and_result_text_success():
+    """A successful JSON result parses and yields the markdown report."""
     stdout = '{"type": "result", "is_error": false, "result": "# Report\\n\\nbody"}'
-    assert ClaudeCodeProvider._parse_output(stdout) == "# Report\n\nbody"
+    data = ClaudeCodeProvider._load_payload(stdout)
+    assert ClaudeCodeProvider._result_text(data) == "# Report\n\nbody"
 
 
-def test_parse_output_raises_on_error_flag():
+def test_load_payload_raises_on_error_flag():
     """An is_error result raises a ValueError with the detail."""
     stdout = '{"is_error": true, "subtype": "error_max_turns", "result": "hit limit"}'
     with pytest.raises(ValueError, match="error_max_turns"):
-        ClaudeCodeProvider._parse_output(stdout)
+        ClaudeCodeProvider._load_payload(stdout)
 
 
-def test_parse_output_raises_on_invalid_json():
+def test_load_payload_raises_on_invalid_json():
     """Non-JSON output raises a ValueError."""
     with pytest.raises(ValueError, match="parse Claude Code JSON"):
-        ClaudeCodeProvider._parse_output("not json at all")
+        ClaudeCodeProvider._load_payload("not json at all")
 
 
-def test_parse_output_raises_on_empty_output():
+def test_load_payload_raises_on_empty_output():
     """Empty stdout raises a ValueError."""
     with pytest.raises(ValueError, match="empty output"):
-        ClaudeCodeProvider._parse_output("   ")
+        ClaudeCodeProvider._load_payload("   ")
 
 
-def test_parse_output_raises_on_missing_result():
-    """A JSON object with no usable result text raises a ValueError."""
+def test_result_text_raises_on_missing_result():
+    """A payload with no usable result text raises a ValueError."""
     with pytest.raises(ValueError, match="no result text"):
-        ClaudeCodeProvider._parse_output('{"is_error": false, "result": ""}')
+        ClaudeCodeProvider._result_text({"is_error": False, "result": ""})
 
 
 def test_extract_run_metadata_reads_actual_models_and_usage():
@@ -204,11 +215,35 @@ def test_extract_citations_handles_no_urls():
 @pytest.mark.asyncio
 async def test_research_raises_on_empty_query():
     """An empty query is rejected before invoking the CLI."""
-    provider = make_provider()
-    if not provider.is_available():
-        pytest.skip("claude CLI not available")
+    # Use a trivially-available executable so the check doesn't depend on `claude`.
+    provider = make_provider(ClaudeCodeParams(claude_executable="true"))
     with pytest.raises(ValueError, match="must not be empty"):
         await provider.research("   ")
+
+
+@pytest.mark.asyncio
+async def test_research_raises_on_nonzero_exit():
+    """A non-zero exit from the CLI surfaces as a ValueError."""
+    if shutil.which("false") is None:
+        pytest.skip("`false` not available")
+    # `false` ignores stdin/args and exits 1 immediately.
+    provider = make_provider(ClaudeCodeParams(claude_executable="false"))
+    with pytest.raises(ValueError, match="exited with code"):
+        await provider.research("anything")
+
+
+@pytest.mark.asyncio
+async def test_research_raises_on_timeout(tmp_path):
+    """A run that exceeds the timeout is killed and surfaces as a ValueError."""
+    script = tmp_path / "slowclaude"
+    script.write_text("#!/bin/sh\nsleep 5\n")
+    script.chmod(0o755)
+    config = ProviderConfig(name="claude_code", api_key=None, enabled=True, timeout=1)
+    provider = ClaudeCodeProvider(
+        config, ClaudeCodeParams(claude_executable=str(script))
+    )
+    with pytest.raises(ValueError, match="timed out"):
+        await provider.research("anything")
 
 
 @pytest.mark.integration

--- a/tests/test_claude_code_provider.py
+++ b/tests/test_claude_code_provider.py
@@ -1,0 +1,231 @@
+"""Tests for the Claude Code provider.
+
+These focus on the pure, side-effect-free helpers (command building, output
+parsing, citation extraction, availability) so they run without invoking the
+real ``claude`` CLI. A single integration test exercises an actual run and is
+skipped automatically when the CLI is unavailable.
+"""
+
+import shutil
+
+import pytest
+
+from deep_research_client.providers.claude_code import (
+    ClaudeCodeProvider,
+    _INLINE_REPORT_DIRECTIVE,
+)
+from deep_research_client.models import ProviderConfig
+from deep_research_client.provider_params import ClaudeCodeParams
+from deep_research_client.system_prompts import DEFAULT_RESEARCH_SYSTEM_PROMPT
+
+
+def make_provider(params: ClaudeCodeParams | None = None) -> ClaudeCodeProvider:
+    """Build a provider with a standard test config."""
+    config = ProviderConfig(name="claude_code", api_key=None, enabled=True)
+    return ClaudeCodeProvider(config, params)
+
+
+def test_default_model():
+    """The provider advertises its sentinel default model."""
+    provider = make_provider()
+    assert provider.get_default_model() == "claude-code-default"
+    assert provider.model == "claude-code-default"
+
+
+def test_is_available_false_when_executable_missing():
+    """An unresolvable executable name means the provider is unavailable."""
+    provider = make_provider(
+        ClaudeCodeParams(claude_executable="definitely-not-a-real-binary-xyz")
+    )
+    assert provider.is_available() is False
+
+
+def test_is_available_false_when_disabled():
+    """A disabled config is never available, even if the CLI exists."""
+    config = ProviderConfig(name="claude_code", api_key=None, enabled=False)
+    provider = ClaudeCodeProvider(config)
+    assert provider.is_available() is False
+
+
+def test_build_command_defaults():
+    """Default command runs print mode, JSON output, and skips permissions."""
+    provider = make_provider()
+    command = provider._build_command()
+
+    assert command[0] == "claude"
+    assert "--print" in command
+    assert command[command.index("--output-format") + 1] == "json"
+    assert "--dangerously-skip-permissions" in command
+    # The research system prompt plus the inline-report directive are appended.
+    assert "--append-system-prompt" in command
+    appended = command[command.index("--append-system-prompt") + 1]
+    assert appended.startswith(DEFAULT_RESEARCH_SYSTEM_PROMPT)
+    assert _INLINE_REPORT_DIRECTIVE in appended
+    # No model is forwarded for the default sentinel.
+    assert "--model" not in command
+
+
+def test_build_command_forwards_explicit_model():
+    """A real model string is forwarded verbatim to --model."""
+    provider = make_provider(ClaudeCodeParams(model="opus"))
+    command = provider._build_command()
+    assert command[command.index("--model") + 1] == "opus"
+
+
+@pytest.mark.parametrize("alias", ["claude", "claude-code", "cc", "default", "claude-code-default"])
+def test_build_command_omits_model_for_sentinel_aliases(alias):
+    """Provider-internal aliases should not be forwarded as a real model."""
+    provider = make_provider(ClaudeCodeParams(model=alias))
+    assert "--model" not in provider._build_command()
+
+
+def test_build_command_custom_system_prompt():
+    """A custom system prompt overrides the default research prompt."""
+    provider = make_provider(ClaudeCodeParams(system_prompt="Be terse."))
+    command = provider._build_command()
+    appended = command[command.index("--append-system-prompt") + 1]
+    assert appended.startswith("Be terse.")
+    assert _INLINE_REPORT_DIRECTIVE in appended
+
+
+def test_build_command_permission_mode_when_not_skipping():
+    """When not skipping permissions, the permission mode is passed instead."""
+    provider = make_provider(
+        ClaudeCodeParams(skip_permissions=False, permission_mode="plan")
+    )
+    command = provider._build_command()
+    assert "--dangerously-skip-permissions" not in command
+    assert command[command.index("--permission-mode") + 1] == "plan"
+
+
+def test_build_command_allowed_tools_and_dirs_and_extra_args():
+    """Allowed tools, add-dirs, and extra args are all forwarded."""
+    provider = make_provider(
+        ClaudeCodeParams(
+            allowed_tools=["WebSearch", "WebFetch"],
+            add_dirs=["/data/a", "/data/b"],
+            extra_args=["--max-turns", "30"],
+        )
+    )
+    command = provider._build_command()
+    assert command[command.index("--allowedTools") + 1] == "WebSearch,WebFetch"
+    # Two --add-dir flags, one per directory.
+    assert command.count("--add-dir") == 2
+    assert "/data/a" in command and "/data/b" in command
+    # extra_args are appended verbatim at the end.
+    assert command[-2:] == ["--max-turns", "30"]
+
+
+def test_parse_output_success():
+    """A successful JSON result yields the markdown report."""
+    stdout = '{"type": "result", "is_error": false, "result": "# Report\\n\\nbody"}'
+    assert ClaudeCodeProvider._parse_output(stdout) == "# Report\n\nbody"
+
+
+def test_parse_output_raises_on_error_flag():
+    """An is_error result raises a ValueError with the detail."""
+    stdout = '{"is_error": true, "subtype": "error_max_turns", "result": "hit limit"}'
+    with pytest.raises(ValueError, match="error_max_turns"):
+        ClaudeCodeProvider._parse_output(stdout)
+
+
+def test_parse_output_raises_on_invalid_json():
+    """Non-JSON output raises a ValueError."""
+    with pytest.raises(ValueError, match="parse Claude Code JSON"):
+        ClaudeCodeProvider._parse_output("not json at all")
+
+
+def test_parse_output_raises_on_empty_output():
+    """Empty stdout raises a ValueError."""
+    with pytest.raises(ValueError, match="empty output"):
+        ClaudeCodeProvider._parse_output("   ")
+
+
+def test_parse_output_raises_on_missing_result():
+    """A JSON object with no usable result text raises a ValueError."""
+    with pytest.raises(ValueError, match="no result text"):
+        ClaudeCodeProvider._parse_output('{"is_error": false, "result": ""}')
+
+
+def test_extract_run_metadata_reads_actual_models_and_usage():
+    """Run metadata should surface the real model(s), cost, turns, and searches."""
+    data = {
+        "result": "report",
+        "num_turns": 12,
+        "total_cost_usd": 0.34,
+        "session_id": "sess-abc",
+        "stop_reason": "end_turn",
+        "modelUsage": {
+            "claude-opus-4-8[1m]": {"outputTokens": 100, "webSearchRequests": 5},
+        },
+    }
+    metadata = ClaudeCodeProvider._extract_run_metadata(data)
+    assert metadata["models_used"] == ["claude-opus-4-8[1m]"]
+    assert metadata["num_turns"] == 12
+    assert metadata["total_cost_usd"] == 0.34
+    assert metadata["web_search_requests"] == 5
+    assert metadata["session_id"] == "sess-abc"
+    assert metadata["stop_reason"] == "end_turn"
+
+
+def test_extract_run_metadata_handles_multiple_models():
+    """If the run used more than one model, all are reported, sorted."""
+    data = {
+        "modelUsage": {
+            "claude-sonnet-4-6": {"webSearchRequests": 1},
+            "claude-opus-4-8[1m]": {"webSearchRequests": 2},
+        }
+    }
+    metadata = ClaudeCodeProvider._extract_run_metadata(data)
+    assert metadata["models_used"] == ["claude-opus-4-8[1m]", "claude-sonnet-4-6"]
+    assert metadata["web_search_requests"] == 3
+
+
+def test_extract_run_metadata_empty_when_absent():
+    """A payload with no usage info yields empty metadata, not errors."""
+    assert ClaudeCodeProvider._extract_run_metadata({"result": "x"}) == {}
+
+
+def test_extract_citations_dedupes_and_strips_trailing_punctuation():
+    """Citation extraction collects unique URLs in order, trimming punctuation."""
+    markdown = (
+        "See https://example.com/a, and also https://example.com/b. "
+        "Again https://example.com/a for emphasis."
+    )
+    citations = ClaudeCodeProvider._extract_citations(markdown)
+    assert citations == ["https://example.com/a", "https://example.com/b"]
+
+
+def test_extract_citations_handles_no_urls():
+    """Markdown without URLs yields no citations."""
+    assert ClaudeCodeProvider._extract_citations("Plain text, no links.") == []
+
+
+@pytest.mark.asyncio
+async def test_research_raises_on_empty_query():
+    """An empty query is rejected before invoking the CLI."""
+    provider = make_provider()
+    if not provider.is_available():
+        pytest.skip("claude CLI not available")
+    with pytest.raises(ValueError, match="must not be empty"):
+        await provider.research("   ")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_research_end_to_end():
+    """Run a tiny real research query through the local Claude Code CLI."""
+    if shutil.which("claude") is None:
+        pytest.skip("claude CLI not available")
+
+    provider = make_provider()
+    result = await provider.research(
+        "In one sentence, what is CRISPR? You may answer from prior knowledge."
+    )
+    assert result.markdown.strip()
+    assert result.provider == "claude_code"
+    assert result.duration_seconds is not None
+    # Provenance: the real model id should be reported, not our sentinel default.
+    assert result.run_metadata is not None
+    assert result.run_metadata.get("models_used")
+    assert result.model != "claude-code-default"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -14,6 +14,7 @@ from deep_research_client.providers import ResearchProvider
 from deep_research_client.providers.asta import AstaProvider
 from deep_research_client.providers.falcon import FalconProvider
 from deep_research_client.providers.openscientist import OpenScientistProvider
+from deep_research_client.providers.claude_code import ClaudeCodeProvider
 
 
 class MockProvider(ResearchProvider):
@@ -195,6 +196,20 @@ def test_openscientist_cache_params_include_artifact_version_tag():
     cache_params = client._get_cache_provider_params(provider)
 
     assert cache_params == {"_cache_version": "artifacts-v1"}
+
+
+def test_claude_code_cache_params_include_version_tag():
+    """Claude Code cache keys should invalidate entries from older prompt scaffolding."""
+    cache_config = CacheConfig(enabled=False)
+    with patch.dict(os.environ, {}, clear=True):
+        client = DeepResearchClient(cache_config=cache_config)
+
+    provider = ClaudeCodeProvider(
+        ProviderConfig(name="claude_code", api_key=None, enabled=True)
+    )
+    cache_params = client._get_cache_provider_params(provider)
+
+    assert cache_params == {"_cache_version": "inline-report-v1"}
 
 
 async def test_research_with_mock_provider():


### PR DESCRIPTION
Closes #55.

Adds **Claude Code** as a deep-research provider, callable identically to every other provider (`client.research(query, provider="claude_code")` or `--provider claude_code`). Because Claude Code is a workflow rather than an HTTP API, the provider drives the local `claude` CLI as a subprocess.

## How it works
- Runs `claude --print --output-format json --dangerously-skip-permissions --append-system-prompt <research prompt>` and pipes the query in via stdin.
- Lets Claude Code's own agentic tools (web search, web fetch, etc.) carry out the research, then parses the JSON and returns a cited markdown report.
- **No API key required** — auth/billing is handled by the local Claude Code installation. Auto-detected whenever `claude` is on PATH; opt out with `DISABLE_CLAUDE_CODE_PROVIDER=true`.

## Notable design points
- **Inline-report directive.** In `--print` mode there is no "later," so a local deep-research skill that defers to a background workflow would leave us with only a chatty preamble. The provider appends a directive instructing Claude Code to produce the finished report inline and not hand off to a background task.
- **Run provenance.** The requested model is the wrong thing to record (and it can change mid-flight). Instead we read the model(s) that actually ran from the run's `modelUsage`, plus cost, turns, web-search count, and session id. These land in a new provider-agnostic `ResearchResult.run_metadata` field and in the formatted frontmatter.
- **Cache versioning.** Bumps the `claude_code` cache version so entries from older prompt scaffolding don't shadow current results.

## Commits
1. Code — provider, params, wiring, provenance, cache version.
2. Docs — README, provider reference, and a full example report.
3. Tests — unit + integration + cache-version tests.

## Testing
- `just test` -> 307 passed, mypy + ruff clean.
- Verified end-to-end against a real `claude` CLI: produced full cited reports (the gut-microbiome/Parkinson's example in `docs/examples/` has 24 citations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
