### PR TITLE
Fix claude_code dropping the report to its final message (#59)

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,8 @@ result = client.research(
 - Auto-detected whenever `claude` is on PATH; set `DISABLE_CLAUDE_CODE_PROVIDER=true` to opt out.
 - **Security:** by default the agent is restricted to a read-only research toolset (`allowed_tools` = `["WebSearch", "WebFetch"]`), so even an untrusted query cannot edit files or run shell commands. Setting `skip_permissions=True` adds `--dangerously-skip-permissions`, which bypasses all permission checks and **makes `allowed_tools` a no-op** (all tools become available) — use it only in trusted, sandboxed environments.
 - **Reading local documents:** the default toolset is web-only and omits the `Read` tool. To research over files you supply (e.g. via `add_dirs`), add `Read` to `allowed_tools` explicitly: `allowed_tools=["WebSearch", "WebFetch", "Read"]`. It is left out by default because filesystem read access is unnecessary for web research and is a mild information-disclosure surface for untrusted queries.
-- **Empty-report guard:** a report shorter than `min_report_chars` (default 200) raises instead of writing a well-formed file containing no research. Set `min_report_chars=0` if you expect short answers.
+- **Empty-report guard (behavior change):** a report shorter than `min_report_chars` (default 200) now raises instead of writing a well-formed file containing no research. Runs that previously returned a short answer successfully will now fail — set `min_report_chars=0` if you expect short answers. This is an emptiness check, not a quality check.
+- **Full-response capture:** every assistant message forms the report, so narration between tool calls appears alongside the research, and `citation_count` includes URLs mentioned in that narration.
 
 #### OpenScientist-Specific Parameters (Autonomous Research)
 

--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ params = ClaudeCodeParams(
     skip_permissions=False,        # default; True bypasses ALL checks (see below)
     add_dirs=["/data/papers"],     # optional --add-dir entries
     working_dir=None,              # optional cwd for the run
+    min_report_chars=200,          # fail loudly on an implausibly short report (0 disables)
     extra_args=["--max-turns", "30"],  # escape hatch for unmodeled flags
 )
 
@@ -330,6 +331,7 @@ result = client.research(
 - Auto-detected whenever `claude` is on PATH; set `DISABLE_CLAUDE_CODE_PROVIDER=true` to opt out.
 - **Security:** by default the agent is restricted to a read-only research toolset (`allowed_tools` = `["WebSearch", "WebFetch"]`), so even an untrusted query cannot edit files or run shell commands. Setting `skip_permissions=True` adds `--dangerously-skip-permissions`, which bypasses all permission checks and **makes `allowed_tools` a no-op** (all tools become available) — use it only in trusted, sandboxed environments.
 - **Reading local documents:** the default toolset is web-only and omits the `Read` tool. To research over files you supply (e.g. via `add_dirs`), add `Read` to `allowed_tools` explicitly: `allowed_tools=["WebSearch", "WebFetch", "Read"]`. It is left out by default because filesystem read access is unnecessary for web research and is a mild information-disclosure surface for untrusted queries.
+- **Empty-report guard:** a report shorter than `min_report_chars` (default 200) raises instead of writing a well-formed file containing no research. Set `min_report_chars=0` if you expect short answers.
 
 #### OpenScientist-Specific Parameters (Autonomous Research)
 

--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -325,6 +325,13 @@ becomes part of the report. The simpler `json` output format exposes only a
 report and then emitted any closing remark would lose the whole report while
 still exiting 0 with valid provenance ([#59](https://github.com/monarch-initiative/deep-research-client/issues/59)).
 
+Because every assistant message is kept, any narration the agent emits between
+tool calls ("Let me search for X…") appears in the report alongside the research.
+That is a deliberate trade — including narration is cosmetic, whereas selecting a
+single message risks dropping the report — but it has one consequence worth
+knowing: citations are extracted from the joined text, so a URL mentioned only in
+passing is counted in `citation_count`.
+
 ### Setup
 
 No API key is needed — authentication and billing are handled by your local
@@ -361,17 +368,28 @@ When `skip_permissions` is `False` (the default), you can also set
 A run that produces no research is the expensive failure mode, because it still
 writes a well-formed file with real cost and provenance metadata — easy to skim
 past and mistake for a real report. `min_report_chars` (default 200) turns that
-into a raised `ValueError` and a non-zero exit. Set it to `0` when short answers
-are expected.
+into a raised `ValueError` and a non-zero exit. The rejected text is logged in
+full and previewed in the exception, so a failed run is diagnosable without
+paying for a second one.
 
-Two `run_metadata` fields help diagnose a thin result after the fact:
+!!! warning "This default is a behavior change"
+
+    Runs that previously returned a short answer successfully now raise. A
+    one-sentence reply is typically under 200 characters. Set
+    `min_report_chars=0` if you expect short answers.
+
+This is an emptiness check, not a quality one — a 250-character *"I was unable to
+find sufficient information on this topic"* passes it cleanly.
+
+Three `run_metadata` fields help diagnose a thin result after the fact:
 
 - `assistant_text_blocks` — how many separate assistant messages the report was
-  assembled from. More than one means the agent spoke again after its main
-  output.
-- `permission_denials` — how many tool calls were refused. A non-zero count often
-  explains a thin report: the agent asked for a tool outside `allowed_tools` and
-  gave up.
+  assembled from. More than one is normal for an agentic run; this is provenance
+  for how the report was assembled, not a warning sign.
+- `permission_denials` — how many tool calls were refused.
+- `denied_tools` — which tools were refused. A non-zero count often explains a
+  thin report: the agent asked for a tool outside `allowed_tools` and gave up,
+  and this names what to add.
 
 ### Security
 
@@ -427,6 +445,9 @@ actual model(s) used and run provenance (`run_metadata`).
 - Restricted to a read-only research toolset by default; broaden `allowed_tools`
   (or enable `skip_permissions` in a sandbox) for tasks that need more
 - Non-deterministic results
+- The `stream-json` output carries every tool result, including full fetched page
+  bodies, so a fetch-heavy run can buffer tens of MB of stdout in memory. Not a
+  correctness problem, but worth knowing for long runs.
 
 ---
 

--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -316,8 +316,14 @@ This is useful for:
 Claude Code is a local command-line tool rather than an HTTP API. This provider
 shells out to the `claude` binary in non-interactive ("print") mode, pipes the
 research prompt to it via stdin, and lets Claude Code's own agentic tools (web
-search, web fetch, file reading) carry out the research. The final answer comes
-back as a cited markdown report.
+search, web fetch, file reading) carry out the research. The response comes back
+as a cited markdown report.
+
+Output is read as a `stream-json` event stream so that *every* assistant message
+becomes part of the report. The simpler `json` output format exposes only a
+`result` field holding the agent's final message, so an agent that wrote its
+report and then emitted any closing remark would lose the whole report while
+still exiting 0 with valid provenance ([#59](https://github.com/monarch-initiative/deep-research-client/issues/59)).
 
 ### Setup
 
@@ -342,12 +348,30 @@ params = ClaudeCodeParams(
     skip_permissions=False,       # default; True bypasses ALL checks (see Security)
     add_dirs=["/data/papers"],    # optional --add-dir entries
     working_dir="/tmp/research",  # optional cwd for the run
+    min_report_chars=200,         # fail on an implausibly short report (0 disables)
     extra_args=["--max-turns", "30"],  # escape hatch for unmodeled flags
 )
 ```
 
 When `skip_permissions` is `False` (the default), you can also set
 `permission_mode` (e.g. `"plan"` or `"acceptEdits"`).
+
+### Failing loudly on an empty report
+
+A run that produces no research is the expensive failure mode, because it still
+writes a well-formed file with real cost and provenance metadata — easy to skim
+past and mistake for a real report. `min_report_chars` (default 200) turns that
+into a raised `ValueError` and a non-zero exit. Set it to `0` when short answers
+are expected.
+
+Two `run_metadata` fields help diagnose a thin result after the fact:
+
+- `assistant_text_blocks` — how many separate assistant messages the report was
+  assembled from. More than one means the agent spoke again after its main
+  output.
+- `permission_denials` — how many tool calls were refused. A non-zero count often
+  explains a thin report: the agent asked for a tool outside `allowed_tools` and
+  gave up.
 
 ### Security
 

--- a/src/deep_research_client/provider_params.py
+++ b/src/deep_research_client/provider_params.py
@@ -401,6 +401,16 @@ class ClaudeCodeParams(BaseProviderParams):
             "Overridden by ProviderConfig.timeout when that is set."
         )
     )
+    min_report_chars: int = Field(
+        default=200,
+        ge=0,
+        description=(
+            "Minimum plausible length, in characters, of the returned report. A "
+            "shorter result raises rather than writing a well-formed file with no "
+            "research in it, which is otherwise a silent and expensive no-op. Set "
+            "to 0 to disable the check when short answers are expected."
+        )
+    )
     extra_args: List[str] = Field(
         default_factory=list,
         description=(

--- a/src/deep_research_client/providers/claude_code.py
+++ b/src/deep_research_client/providers/claude_code.py
@@ -4,7 +4,14 @@ Unlike the API-based providers, Claude Code is a local command-line tool (the
 ``claude`` binary). This provider drives it in non-interactive "print" mode,
 piping the research prompt to it and letting Claude Code's own agentic tools
 (web search, web fetch, file reading, etc.) carry out a multi-step research
-workflow. The final answer is returned as a cited markdown report.
+workflow. The full response is returned as a cited markdown report.
+
+Output is read as a ``stream-json`` event stream rather than the simpler ``json``
+format. The latter exposes only a ``result`` field holding the agent's *final*
+message, so an agent that writes its report and then emits any closing remark
+loses the entire report -- silently, since the run still exits 0 with valid
+provenance metadata. Reading the stream lets us join every assistant text block
+while still taking run metadata from the terminal ``result`` event.
 
 No provider API key is required: billing and authentication are handled by the
 local Claude Code installation.
@@ -138,11 +145,15 @@ class ClaudeCodeProvider(ResearchProvider):
         Returns:
             The argument list to pass to ``asyncio.create_subprocess_exec``.
         """
+        # stream-json (which requires --verbose in print mode) preserves every
+        # assistant message; the plain "json" format would give us only the last
+        # one. See the module docstring.
         command: List[str] = [
             self.claude_executable,
             "--print",
             "--output-format",
-            "json",
+            "stream-json",
+            "--verbose",
         ]
 
         if self.params.skip_permissions:
@@ -206,9 +217,15 @@ class ClaudeCodeProvider(ResearchProvider):
                 f"{stderr.strip() or '<no stderr>'}"
             )
 
-        data = self._load_payload(stdout)
-        markdown = self._result_text(data)
+        assistant_texts, data = self._parse_stream(stdout)
+        markdown = self._report_text(assistant_texts, data)
+        self._check_report_length(markdown, self.params.min_report_chars)
+
         run_metadata = self._extract_run_metadata(data)
+        # How many separate assistant messages the report was assembled from. A
+        # value above 1 means the agent spoke again after its main output, the
+        # shape that used to truncate the report entirely.
+        run_metadata["assistant_text_blocks"] = len(assistant_texts)
         citations = self._extract_citations(markdown)
 
         # Prefer the model id(s) the run actually reported over our sentinel
@@ -281,45 +298,119 @@ class ClaudeCodeProvider(ResearchProvider):
         )
 
     @staticmethod
-    def _load_payload(stdout: str) -> dict:
-        """Parse and validate Claude Code's JSON output into a dict.
+    def _parse_stream(stdout: str) -> tuple[List[str], dict]:
+        """Parse Claude Code's ``stream-json`` output into text blocks and metadata.
+
+        The stream is JSON Lines: one event per line. ``assistant`` events carry
+        the model's own output (text, thinking, and tool_use blocks, split across
+        events); the terminal ``result`` event carries the run's provenance and
+        error status.
 
         Args:
-            stdout: Raw stdout from ``claude --print --output-format json``.
+            stdout: Raw stdout from ``claude --print --output-format stream-json``.
 
         Returns:
-            The parsed JSON payload.
+            Tuple of (assistant text blocks in emission order, terminal result event).
 
         Raises:
-            ValueError: If the output is empty, not valid JSON, or reports an error.
+            ValueError: If the output is empty, contains no terminal result event,
+                or that event reports an error.
         """
         text = stdout.strip()
         if not text:
             raise ValueError("Claude Code returned empty output.")
 
-        try:
-            data = json.loads(text)
-        except json.JSONDecodeError as exc:
-            raise ValueError(f"Could not parse Claude Code JSON output: {exc}")
+        assistant_texts: List[str] = []
+        result_event: Optional[dict] = None
 
-        if data.get("is_error"):
-            subtype = data.get("subtype", "unknown error")
-            detail = data.get("result") or subtype
+        for line in text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                # A stray non-JSON line (a warning, say) should not sink an
+                # otherwise complete run; a genuinely unparseable stream is
+                # caught below by the missing result event.
+                logger.warning(
+                    "Skipping unparseable line in Claude Code output: %.200s", line
+                )
+                continue
+
+            if not isinstance(event, dict):
+                continue
+
+            if event.get("type") == "assistant":
+                content = event.get("message", {}).get("content") or []
+                for block in content:
+                    if isinstance(block, dict) and block.get("type") == "text":
+                        block_text = str(block.get("text") or "")
+                        if block_text.strip():
+                            assistant_texts.append(block_text)
+            elif event.get("type") == "result":
+                result_event = event
+
+        if result_event is None:
+            raise ValueError(
+                "Could not parse Claude Code JSON output: the stream contained no "
+                "terminal 'result' event, so the run did not complete."
+            )
+
+        if result_event.get("is_error"):
+            subtype = result_event.get("subtype", "unknown error")
+            detail = result_event.get("result") or subtype
             raise ValueError(f"Claude Code reported an error ({subtype}): {detail}")
 
-        return data
+        return assistant_texts, result_event
 
     @staticmethod
-    def _result_text(data: dict) -> str:
-        """Extract the markdown report text from a parsed payload.
+    def _report_text(assistant_texts: List[str], data: dict) -> str:
+        """Assemble the markdown report from every assistant text block.
+
+        Falls back to the terminal event's ``result`` field only when the stream
+        carried no assistant text at all. That field holds just the agent's final
+        message, so preferring the joined blocks is what keeps a report from
+        being truncated to its closing remark.
+
+        Args:
+            assistant_texts: Assistant text blocks in emission order.
+            data: The terminal ``result`` event.
 
         Raises:
-            ValueError: If the payload contains no usable result text.
+            ValueError: If neither source yields any text.
         """
+        if assistant_texts:
+            return "\n\n".join(block.strip() for block in assistant_texts)
+
         result = data.get("result")
         if not result or not str(result).strip():
             raise ValueError("Claude Code output contained no result text.")
         return str(result)
+
+    @staticmethod
+    def _check_report_length(markdown: str, min_chars: int) -> None:
+        """Reject a report too short to be a plausible research result.
+
+        Silent success on an empty run is the costly failure mode: the caller
+        gets a well-formed file with real provenance and no content. Failing here
+        turns that into a non-zero exit.
+
+        Raises:
+            ValueError: If ``markdown`` is shorter than ``min_chars``.
+        """
+        if min_chars <= 0:
+            return
+
+        length = len(markdown.strip())
+        if length < min_chars:
+            raise ValueError(
+                f"Claude Code returned a {length}-character report, below the "
+                f"min_report_chars threshold of {min_chars}. This usually means "
+                "the run failed, was cut short, or produced no research. Lower or "
+                "disable the threshold (min_report_chars=0) if short answers are "
+                "expected."
+            )
 
     @staticmethod
     def _extract_run_metadata(data: dict) -> dict:
@@ -330,11 +421,11 @@ class ClaudeCodeProvider(ResearchProvider):
         mid-flight.
 
         Args:
-            data: Parsed Claude Code JSON payload.
+            data: The terminal ``result`` event from the output stream.
 
         Returns:
             A metadata dict with any of: models_used, num_turns, total_cost_usd,
-            web_search_requests, session_id, stop_reason.
+            web_search_requests, session_id, stop_reason, permission_denials.
         """
         metadata: dict = {}
 
@@ -358,6 +449,12 @@ class ClaudeCodeProvider(ResearchProvider):
             metadata["session_id"] = data["session_id"]
         if data.get("stop_reason"):
             metadata["stop_reason"] = data["stop_reason"]
+
+        # Denied tool calls are a common cause of a thin report: the agent asked
+        # for a tool outside the allowlist, was refused, and gave up.
+        denials = data.get("permission_denials")
+        if denials:
+            metadata["permission_denials"] = len(denials)
 
         return metadata
 

--- a/src/deep_research_client/providers/claude_code.py
+++ b/src/deep_research_client/providers/claude_code.py
@@ -222,9 +222,10 @@ class ClaudeCodeProvider(ResearchProvider):
         self._check_report_length(markdown, self.params.min_report_chars)
 
         run_metadata = self._extract_run_metadata(data)
-        # How many separate assistant messages the report was assembled from. A
-        # value above 1 means the agent spoke again after its main output, the
-        # shape that used to truncate the report entirely.
+        # How many separate assistant messages the report was assembled from.
+        # More than one is normal for an agentic run (the model narrates between
+        # tool calls); the count is provenance for how the report was assembled,
+        # not a warning sign.
         run_metadata["assistant_text_blocks"] = len(assistant_texts)
         citations = self._extract_citations(markdown)
 
@@ -342,7 +343,19 @@ class ClaudeCodeProvider(ResearchProvider):
                 continue
 
             if event.get("type") == "assistant":
-                content = event.get("message", {}).get("content") or []
+                # `message` can be an explicit null, and `content` is a plain
+                # string in the single-text-block form the Anthropic message
+                # format permits. Neither is what the CLI emits today, but
+                # iterating a string would silently yield characters that the
+                # block guard below drops -- a truncated report with no signal.
+                message = event.get("message")
+                if not isinstance(message, dict):
+                    continue
+                content = message.get("content")
+                if isinstance(content, str):
+                    content = [{"type": "text", "text": content}]
+                elif not isinstance(content, list):
+                    continue
                 for block in content:
                     if isinstance(block, dict) and block.get("type") == "text":
                         block_text = str(block.get("text") or "")
@@ -373,6 +386,12 @@ class ClaudeCodeProvider(ResearchProvider):
         message, so preferring the joined blocks is what keeps a report from
         being truncated to its closing remark.
 
+        Joining everything means any narration the model emits between tool calls
+        ("Let me search for X...") lands in the report too. That is the deliberate
+        trade: including narration is a cosmetic cost, whereas picking a single
+        block risks dropping the research. Note that citation extraction runs over
+        the joined text, so a URL mentioned only in narration is counted.
+
         Args:
             assistant_texts: Assistant text blocks in emission order.
             data: The terminal ``result`` event.
@@ -386,7 +405,7 @@ class ClaudeCodeProvider(ResearchProvider):
         result = data.get("result")
         if not result or not str(result).strip():
             raise ValueError("Claude Code output contained no result text.")
-        return str(result)
+        return str(result).strip()
 
     @staticmethod
     def _check_report_length(markdown: str, min_chars: int) -> None:
@@ -396,21 +415,38 @@ class ClaudeCodeProvider(ResearchProvider):
         gets a well-formed file with real provenance and no content. Failing here
         turns that into a non-zero exit.
 
+        This is an emptiness check, not a quality one: a short "I could not find
+        sufficient information" reply passes it.
+
+        Because the run that failed has already been paid for, the rejected text
+        is logged in full and previewed in the exception, so the cause is
+        diagnosable without a second run.
+
         Raises:
             ValueError: If ``markdown`` is shorter than ``min_chars``.
         """
         if min_chars <= 0:
             return
 
-        length = len(markdown.strip())
-        if length < min_chars:
-            raise ValueError(
-                f"Claude Code returned a {length}-character report, below the "
-                f"min_report_chars threshold of {min_chars}. This usually means "
-                "the run failed, was cut short, or produced no research. Lower or "
-                "disable the threshold (min_report_chars=0) if short answers are "
-                "expected."
-            )
+        report = markdown.strip()
+        if len(report) >= min_chars:
+            return
+
+        logger.warning(
+            "Claude Code report is below the min_report_chars threshold (%d < %d). "
+            "Full text of the rejected report: %s",
+            len(report),
+            min_chars,
+            report or "<empty>",
+        )
+        preview = report[:200] + ("..." if len(report) > 200 else "")
+        raise ValueError(
+            f"Claude Code returned a {len(report)}-character report, below the "
+            f"min_report_chars threshold of {min_chars}. This usually means the "
+            "run failed, was cut short, or produced no research. Lower or disable "
+            "the threshold (min_report_chars=0) if short answers are expected. "
+            f"Report text: {preview!r}"
+        )
 
     @staticmethod
     def _extract_run_metadata(data: dict) -> dict:
@@ -451,10 +487,21 @@ class ClaudeCodeProvider(ResearchProvider):
             metadata["stop_reason"] = data["stop_reason"]
 
         # Denied tool calls are a common cause of a thin report: the agent asked
-        # for a tool outside the allowlist, was refused, and gave up.
+        # for a tool outside the allowlist, was refused, and gave up. Which tool
+        # was refused is the actionable half -- it names what to add to
+        # allowed_tools -- so record the names alongside the count.
         denials = data.get("permission_denials")
         if denials:
             metadata["permission_denials"] = len(denials)
+            denied_tools = sorted(
+                {
+                    denial["tool_name"]
+                    for denial in denials
+                    if isinstance(denial, dict) and denial.get("tool_name")
+                }
+            )
+            if denied_tools:
+                metadata["denied_tools"] = denied_tools
 
         return metadata
 

--- a/tests/test_claude_code_provider.py
+++ b/tests/test_claude_code_provider.py
@@ -7,6 +7,7 @@ skipped automatically when the CLI is unavailable.
 """
 
 import json
+import logging
 import shutil
 
 import pytest
@@ -194,6 +195,42 @@ def test_parse_stream_ignores_non_text_blocks():
     assert texts == ["visible answer"]
 
 
+@pytest.mark.parametrize(
+    "message",
+    [
+        None,
+        {},
+        {"content": None},
+        {"content": []},
+        "not a message object",
+    ],
+    ids=["null", "empty", "null-content", "empty-content", "string"],
+)
+def test_parse_stream_tolerates_malformed_assistant_events(message):
+    """A malformed assistant event is skipped, not turned into an AttributeError.
+
+    The method's contract is that it raises ValueError; an explicit
+    ``"message": null`` must not escape that as an AttributeError.
+    """
+    stdout = make_stream(
+        {"type": "assistant", "message": message},
+        assistant_event("the real report"),
+        {"type": "result", "is_error": False, "result": "the real report"},
+    )
+    texts, _ = ClaudeCodeProvider._parse_stream(stdout)
+    assert texts == ["the real report"]
+
+
+def test_parse_stream_accepts_string_content():
+    """Content given as a bare string is a text block, not a sequence of chars."""
+    stdout = make_stream(
+        {"type": "assistant", "message": {"content": "a whole report as one string"}},
+        {"type": "result", "is_error": False, "result": "x"},
+    )
+    texts, _ = ClaudeCodeProvider._parse_stream(stdout)
+    assert texts == ["a whole report as one string"]
+
+
 def test_parse_stream_skips_unparseable_lines():
     """A stray non-JSON line does not sink an otherwise complete run."""
     stdout = "\n".join([
@@ -252,6 +289,26 @@ def test_check_report_length_rejects_implausible_reports(report):
         ClaudeCodeProvider._check_report_length(report, 200)
 
 
+def test_check_report_length_reports_the_rejected_text(caplog):
+    """The rejected run is diagnosable without paying for a second one."""
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(ValueError, match="I could not find sufficient"):
+            ClaudeCodeProvider._check_report_length(
+                "I could not find sufficient information.", 200
+            )
+    assert "I could not find sufficient information." in caplog.text
+
+
+def test_check_report_length_truncates_long_previews():
+    """A long-but-still-too-short report is previewed, not dumped, in the error."""
+    report = "x" * 900
+    with pytest.raises(ValueError) as excinfo:
+        ClaudeCodeProvider._check_report_length(report, 1000)
+    message = str(excinfo.value)
+    assert "..." in message
+    assert len(message) < 600
+
+
 def test_check_report_length_accepts_a_real_report():
     """A report at or above the threshold passes."""
     ClaudeCodeProvider._check_report_length("x" * 200, 200)
@@ -285,10 +342,27 @@ def test_extract_run_metadata_reads_actual_models_and_usage():
     assert "permission_denials" not in metadata
 
 
-def test_extract_run_metadata_counts_permission_denials():
-    """Denied tool calls are surfaced; they often explain a thin report."""
-    data = {"permission_denials": [{"tool_name": "Read"}, {"tool_name": "Bash"}]}
-    assert ClaudeCodeProvider._extract_run_metadata(data)["permission_denials"] == 2
+def test_extract_run_metadata_records_denied_tool_names():
+    """Denied tool calls are surfaced by name; they often explain a thin report."""
+    data = {
+        "permission_denials": [
+            {"tool_name": "Read"},
+            {"tool_name": "Bash"},
+            {"tool_name": "Read"},
+        ]
+    }
+    metadata = ClaudeCodeProvider._extract_run_metadata(data)
+    # The count keeps every denial; the names are deduplicated and sorted, since
+    # they name what to add to allowed_tools.
+    assert metadata["permission_denials"] == 3
+    assert metadata["denied_tools"] == ["Bash", "Read"]
+
+
+def test_extract_run_metadata_denials_without_tool_names():
+    """Denials lacking a tool_name still count, without an empty names list."""
+    metadata = ClaudeCodeProvider._extract_run_metadata({"permission_denials": [{}]})
+    assert metadata["permission_denials"] == 1
+    assert "denied_tools" not in metadata
 
 
 def test_extract_run_metadata_handles_multiple_models():
@@ -342,6 +416,90 @@ async def test_research_raises_on_nonzero_exit():
     provider = make_provider(ClaudeCodeParams(claude_executable="false"))
     with pytest.raises(ValueError, match="exited with code"):
         await provider.research("anything")
+
+
+def write_stub_claude(tmp_path, stdout: str):
+    """Write an executable stub that emits `stdout` like the real CLI would.
+
+    This is a real subprocess, not a mock: it exercises the actual spawn, stdin
+    write, and stream-parsing path that `research()` uses.
+    """
+    script = tmp_path / "stubclaude"
+    payload = tmp_path / "stub_output.jsonl"
+    payload.write_text(stdout)
+    # Drain stdin so the provider's write to it cannot fail with EPIPE.
+    script.write_text(f"#!/bin/sh\ncat > /dev/null\ncat {payload}\n")
+    script.chmod(0o755)
+    return script
+
+
+@pytest.mark.asyncio
+async def test_research_joins_blocks_and_records_provenance(tmp_path):
+    """End-to-end through a stub CLI: the report survives, provenance is recorded."""
+    body = "The substantive findings, at length. " * 10
+    stdout = make_stream(
+        {"type": "system", "subtype": "init"},
+        assistant_event("Let me search for that."),
+        assistant_event(f"# Report\n\n{body}See https://example.com/a for detail."),
+        assistant_event("One correction: nothing else changes."),
+        {
+            "type": "result",
+            "is_error": False,
+            "result": "One correction: nothing else changes.",
+            "num_turns": 3,
+            "session_id": "sess-xyz",
+            "permission_denials": [{"tool_name": "Read"}],
+            "modelUsage": {"claude-opus-5[1m]": {"webSearchRequests": 2}},
+        },
+    )
+    provider = make_provider(
+        ClaudeCodeParams(claude_executable=str(write_stub_claude(tmp_path, stdout)))
+    )
+    result = await provider.research("anything")
+
+    # All three blocks are present -- notably the report, which the final-turn-only
+    # `result` field would have replaced with the sign-off.
+    assert "Let me search for that." in result.markdown
+    assert "The substantive findings" in result.markdown
+    assert "One correction: nothing else changes." in result.markdown
+
+    assert result.citations == ["https://example.com/a"]
+    assert result.run_metadata["assistant_text_blocks"] == 3
+    assert result.run_metadata["num_turns"] == 3
+    assert result.run_metadata["denied_tools"] == ["Read"]
+    # Provenance reports the model that actually ran, not the sentinel default.
+    assert result.model == "claude-opus-5[1m]"
+
+
+@pytest.mark.asyncio
+async def test_research_raises_on_short_report(tmp_path):
+    """A run whose report is too short fails instead of returning an empty result."""
+    stdout = make_stream(
+        assistant_event("done"),
+        {"type": "result", "is_error": False, "result": "done"},
+    )
+    provider = make_provider(
+        ClaudeCodeParams(claude_executable=str(write_stub_claude(tmp_path, stdout)))
+    )
+    with pytest.raises(ValueError, match="min_report_chars"):
+        await provider.research("anything")
+
+
+@pytest.mark.asyncio
+async def test_research_allows_short_report_when_guard_disabled(tmp_path):
+    """min_report_chars=0 opts out for callers that expect short answers."""
+    stdout = make_stream(
+        assistant_event("done"),
+        {"type": "result", "is_error": False, "result": "done"},
+    )
+    provider = make_provider(
+        ClaudeCodeParams(
+            claude_executable=str(write_stub_claude(tmp_path, stdout)),
+            min_report_chars=0,
+        )
+    )
+    result = await provider.research("anything")
+    assert result.markdown == "done"
 
 
 @pytest.mark.asyncio

--- a/tests/test_claude_code_provider.py
+++ b/tests/test_claude_code_provider.py
@@ -6,6 +6,7 @@ real ``claude`` CLI. A single integration test exercises an actual run and is
 skipped automatically when the CLI is unavailable.
 """
 
+import json
 import shutil
 
 import pytest
@@ -47,14 +48,30 @@ def test_is_available_false_when_disabled():
     assert provider.is_available() is False
 
 
+def make_stream(*events: dict) -> str:
+    """Render events as the JSON Lines stream `claude` writes to stdout."""
+    return "\n".join(json.dumps(event) for event in events)
+
+
+def assistant_event(*texts: str) -> dict:
+    """Build an assistant event carrying the given text blocks."""
+    return {
+        "type": "assistant",
+        "message": {"content": [{"type": "text", "text": text} for text in texts]},
+    }
+
+
 def test_build_command_defaults():
-    """Default command runs print mode, JSON output, and a read-only toolset."""
+    """Default command runs print mode, streamed JSON output, and a read-only toolset."""
     provider = make_provider()
     command = provider._build_command()
 
     assert command[0] == "claude"
     assert "--print" in command
-    assert command[command.index("--output-format") + 1] == "json"
+    # stream-json (and its required --verbose) keeps every assistant message;
+    # the plain "json" format exposes only the final one.
+    assert command[command.index("--output-format") + 1] == "stream-json"
+    assert "--verbose" in command
     # Secure default: permissions are NOT skipped, and the agent is restricted to
     # a read-only research toolset via the allowlist.
     assert "--dangerously-skip-permissions" not in command
@@ -126,36 +143,123 @@ def test_build_command_allowed_tools_and_dirs_and_extra_args():
     assert command[-2:] == ["--max-turns", "30"]
 
 
-def test_load_payload_and_result_text_success():
-    """A successful JSON result parses and yields the markdown report."""
-    stdout = '{"type": "result", "is_error": false, "result": "# Report\\n\\nbody"}'
-    data = ClaudeCodeProvider._load_payload(stdout)
-    assert ClaudeCodeProvider._result_text(data) == "# Report\n\nbody"
+def test_parse_stream_and_report_text_success():
+    """A successful stream parses and yields the markdown report."""
+    stdout = make_stream(
+        assistant_event("# Report\n\nbody"),
+        {"type": "result", "is_error": False, "result": "# Report\n\nbody"},
+    )
+    texts, data = ClaudeCodeProvider._parse_stream(stdout)
+    assert ClaudeCodeProvider._report_text(texts, data) == "# Report\n\nbody"
 
 
-def test_load_payload_raises_on_error_flag():
+def test_report_text_joins_all_assistant_messages():
+    """Regression: a trailing message must not replace the report (#59).
+
+    The plain ``json`` output format exposes only the agent's final message, so a
+    run that wrote its report and then signed off used to yield just the sign-off.
+    """
+    stdout = make_stream(
+        {"type": "system", "subtype": "init"},
+        assistant_event("# Report\n\nThe substantive findings."),
+        {"type": "user", "message": {"content": [{"type": "tool_result"}]}},
+        assistant_event("One correction: nothing else changes."),
+        # The terminal event's `result` carries only that final message.
+        {"type": "result", "is_error": False, "result": "One correction: nothing else changes."},
+    )
+    texts, data = ClaudeCodeProvider._parse_stream(stdout)
+    assert len(texts) == 2
+
+    report = ClaudeCodeProvider._report_text(texts, data)
+    assert "The substantive findings." in report
+    assert "One correction: nothing else changes." in report
+
+
+def test_parse_stream_ignores_non_text_blocks():
+    """Thinking and tool_use blocks are not part of the report."""
+    stdout = make_stream(
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {"type": "thinking", "thinking": "internal reasoning"},
+                    {"type": "text", "text": "visible answer"},
+                    {"type": "tool_use", "name": "WebSearch", "input": {}},
+                ]
+            },
+        },
+        {"type": "result", "is_error": False, "result": "visible answer"},
+    )
+    texts, _ = ClaudeCodeProvider._parse_stream(stdout)
+    assert texts == ["visible answer"]
+
+
+def test_parse_stream_skips_unparseable_lines():
+    """A stray non-JSON line does not sink an otherwise complete run."""
+    stdout = "\n".join([
+        "warning: something noisy",
+        json.dumps(assistant_event("the report")),
+        json.dumps({"type": "result", "is_error": False, "result": "the report"}),
+    ])
+    texts, data = ClaudeCodeProvider._parse_stream(stdout)
+    assert texts == ["the report"]
+    assert data["type"] == "result"
+
+
+def test_parse_stream_raises_on_error_flag():
     """An is_error result raises a ValueError with the detail."""
-    stdout = '{"is_error": true, "subtype": "error_max_turns", "result": "hit limit"}'
+    stdout = make_stream(
+        {"type": "result", "is_error": True, "subtype": "error_max_turns", "result": "hit limit"}
+    )
     with pytest.raises(ValueError, match="error_max_turns"):
-        ClaudeCodeProvider._load_payload(stdout)
+        ClaudeCodeProvider._parse_stream(stdout)
 
 
-def test_load_payload_raises_on_invalid_json():
+def test_parse_stream_raises_on_invalid_json():
     """Non-JSON output raises a ValueError."""
     with pytest.raises(ValueError, match="parse Claude Code JSON"):
-        ClaudeCodeProvider._load_payload("not json at all")
+        ClaudeCodeProvider._parse_stream("not json at all")
 
 
-def test_load_payload_raises_on_empty_output():
+def test_parse_stream_raises_when_run_did_not_complete():
+    """A stream cut short before the terminal result event raises."""
+    stdout = make_stream(assistant_event("partial output"))
+    with pytest.raises(ValueError, match="did not complete"):
+        ClaudeCodeProvider._parse_stream(stdout)
+
+
+def test_parse_stream_raises_on_empty_output():
     """Empty stdout raises a ValueError."""
     with pytest.raises(ValueError, match="empty output"):
-        ClaudeCodeProvider._load_payload("   ")
+        ClaudeCodeProvider._parse_stream("   ")
 
 
-def test_result_text_raises_on_missing_result():
-    """A payload with no usable result text raises a ValueError."""
+def test_report_text_falls_back_to_result_field():
+    """With no assistant text blocks, the terminal result field is used."""
+    assert ClaudeCodeProvider._report_text([], {"result": "fallback"}) == "fallback"
+
+
+def test_report_text_raises_when_nothing_available():
+    """No assistant text and no result text raises a ValueError."""
     with pytest.raises(ValueError, match="no result text"):
-        ClaudeCodeProvider._result_text({"is_error": False, "result": ""})
+        ClaudeCodeProvider._report_text([], {"is_error": False, "result": ""})
+
+
+@pytest.mark.parametrize("report", ["", "   ", "Too short to be research."])
+def test_check_report_length_rejects_implausible_reports(report):
+    """An implausibly short report fails loudly instead of being written out."""
+    with pytest.raises(ValueError, match="min_report_chars"):
+        ClaudeCodeProvider._check_report_length(report, 200)
+
+
+def test_check_report_length_accepts_a_real_report():
+    """A report at or above the threshold passes."""
+    ClaudeCodeProvider._check_report_length("x" * 200, 200)
+
+
+def test_check_report_length_disabled_by_zero():
+    """A zero threshold disables the check entirely."""
+    ClaudeCodeProvider._check_report_length("", 0)
 
 
 def test_extract_run_metadata_reads_actual_models_and_usage():
@@ -177,6 +281,14 @@ def test_extract_run_metadata_reads_actual_models_and_usage():
     assert metadata["web_search_requests"] == 5
     assert metadata["session_id"] == "sess-abc"
     assert metadata["stop_reason"] == "end_turn"
+    # No denials in this payload, so the key is omitted rather than zero.
+    assert "permission_denials" not in metadata
+
+
+def test_extract_run_metadata_counts_permission_denials():
+    """Denied tool calls are surfaced; they often explain a thin report."""
+    data = {"permission_denials": [{"tool_name": "Read"}, {"tool_name": "Bash"}]}
+    assert ClaudeCodeProvider._extract_run_metadata(data)["permission_denials"] == 2
 
 
 def test_extract_run_metadata_handles_multiple_models():
@@ -255,7 +367,7 @@ async def test_research_end_to_end():
 
     provider = make_provider()
     result = await provider.research(
-        "In one sentence, what is CRISPR? You may answer from prior knowledge."
+        "In one short paragraph, what is CRISPR? You may answer from prior knowledge."
     )
     assert result.markdown.strip()
     assert result.provider == "claude_code"
@@ -263,4 +375,27 @@ async def test_research_end_to_end():
     # Provenance: the real model id should be reported, not our sentinel default.
     assert result.run_metadata is not None
     assert result.run_metadata.get("models_used")
+    assert result.run_metadata.get("assistant_text_blocks", 0) >= 1
     assert result.model != "claude-code-default"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_research_keeps_output_preceding_a_tool_call():
+    """Regression (#59): content written before a later turn must survive.
+
+    The prompt deliberately induces the shape that used to lose the report --
+    substantive output, then a tool call, then a short closing message -- and
+    asserts the early content is still present.
+    """
+    if shutil.which("claude") is None:
+        pytest.skip("claude CLI not available")
+
+    provider = make_provider(ClaudeCodeParams(model="haiku"))
+    result = await provider.research(
+        "First, write a 150-word essay about granite. Then use WebSearch to search "
+        "for 'granite countertop price'. Then respond with exactly the word: done"
+    )
+    assert "granite" in result.markdown.lower()
+    # The essay dwarfs the "done" sign-off that the old parser would have kept alone.
+    assert len(result.markdown) > 500


### PR DESCRIPTION
Fixes #59. Root cause of the downstream report in [monarch-initiative/dismech#7443](https://github.com/monarch-initiative/dismech/issues/7443).

## The bug

The provider ran `claude --print --output-format json` and read the payload's `result` field. **That field holds only the agent's final message.** An agent that wrote its report and then emitted any closing remark lost the entire report — silently, since the run still exited 0 and wrote a well-formed file with real cost and provenance metadata.

Reproduced against `claude` 2.1.224:

```bash
printf '%s' 'First, write a 150-word essay about granite. Then use WebSearch to search
for "granite countertop price". Then respond with exactly the single word: done' \
  | claude --print --output-format json --model haiku --allowedTools WebSearch
```

```
num_turns: 2
result: 'done'
```

The 1420-character essay is gone. `num_turns: 2` matches the dismech frontmatter exactly, as does the shape: substance first, an incidental closing message last.

## The fix

- **Read `--output-format stream-json --verbose` and join every assistant text block.** Assistant text arrives as separate events, and the terminal `result` event still carries the metadata `_extract_run_metadata` already read, so provenance is unchanged. `_report_text` falls back to `result` only when the stream carried no assistant text at all.
- **`min_report_chars` (default 200)** on `ClaudeCodeParams` — an implausibly short report now raises instead of writing a plausible-looking empty file. Set to `0` when short answers are expected.
- **`assistant_text_blocks` and `permission_denials`** in `run_metadata`, so a multi-message run or a tool-denial-induced thin report is visible in the artifact's provenance rather than needing a re-run to diagnose.

## Verification

- 321 unit tests pass; mypy and ruff clean.
- New unit tests cover the stream parser: multi-message joining (the regression), non-text block filtering, stray non-JSON lines, a stream cut short before the terminal event, the error flag, and the length guard.
- New **integration** test induces the exact failing shape against the real CLI (essay → tool call → sign-off) and asserts the early content survives. Both integration tests pass.
- End-to-end through the CLI the way dismech calls it: a TP53 query returned a complete 6 KB report with `citation_count: 6` and `assistant_text_blocks: 1`.

## Not included

The prompt template being echoed into the output body — which pads an empty report to ~27 KB and makes it look substantial — is cross-provider formatter behavior, already tracked in #52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
