### PR TITLE
Opt-in provider fallback, with the provider that actually produced the report recorded

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ provider_attempts:
   succeeded: true
 ```
 
-Only failures meaning *this provider cannot do the work* are followed. A 429 or a 5xx says to wait and retry the same provider, not to switch, and an unrecognised failure is not evidence that anyone else would do better. From Python:
+Reports and cache entries produced without a fallback gain none of these keys, though the result object always carries `provider_attempts`. Only failures meaning *this provider cannot do the work* are followed. A 429 or a 5xx says to wait and retry the same provider, not to switch, and an unrecognised failure is not evidence that anyone else would do better. From Python:
 
 ```python
 result = client.research("Statins and myopathy", provider="falcon", fallback=True)

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ provider_attempts:
   succeeded: true
 ```
 
-Reports and cache entries produced without a fallback gain none of these keys, though the result object always carries `provider_attempts`. Only failures meaning *this provider cannot do the work* are followed. A 429 or a 5xx says to wait and retry the same provider, not to switch, and an unrecognised failure is not evidence that anyone else would do better. From Python:
+`remedy` is our reading of the failure, not the provider's own error text: that text can quote whatever a provider puts in a response body — including, for a rejected key, the key — and these reports get committed, so the raw version stays on the result object and in the logs. Reports and cache entries produced without a fallback gain none of these keys, though the result object always carries `provider_attempts`. Only failures meaning *this provider cannot do the work* are followed. A 429 or a 5xx says to wait and retry the same provider, not to switch, and an unrecognised failure is not evidence that anyone else would do better. From Python:
 
 ```python
 result = client.research("Statins and myopathy", provider="falcon", fallback=True)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A simple Python wrapper for multiple deep research tools including OpenAI Deep R
 - 📋 **Advanced Templates**: Support for both simple f-string and powerful Jinja2 templates
 - ✅ **Reference Validation**: Resolve every cited PMID, DOI, PMC and GEO identifier, check quoted claims against the source, and flag references that resolve but look off topic
 - 🏷️ **Ontology Term Validation**: Resolve every cited CURIE and check it against the label the report gave it, catching the real term that means something else entirely
+- 🔁 **Opt-in Provider Fallback**: Let another provider take over when one is out of credits or unconfigured, with the provider that actually produced the report recorded on it
 - 🏗️ **Extensible**: Easy to add new research providers
 
 ## Installation
@@ -180,6 +181,46 @@ print(report.to_markdown())          # renderable summary section
 ```
 
 Labels are only read from positions where a label is the only thing the text can be - a table cell, an emphasised run, a bracket or separator right after the CURIE - so a term mentioned in prose is checked for existence but not for naming. That undercounts rather than invents. Comparison runs against every name a term carries, synonyms included, so a report calling `HP:0001166` "Long fingers" rather than "Arachnodactyly" is not accused of anything. See the [Validate Ontology Terms guide](docs/how-to/validate-terms.md) for the full rules, outcomes and [timings](docs/how-to/validate-terms.md#how-long-it-takes).
+
+### Provider Fallback
+
+A run can fail for reasons no retry fixes - an account out of credits, a spent plan allowance, a rejected key. `--fallback` lets another configured provider take the work instead:
+
+```bash
+deep-research-client research "Statins and myopathy" --provider falcon --fallback --output report.md
+
+# Or name the order yourself
+deep-research-client research "CRISPR delivery" \
+  --provider falcon --fallback-provider openai --fallback-provider perplexity
+```
+
+It is off by default on purpose. A report records the provider that produced it, and downstream curation reads that field, so a silent switch would make those records wrong. When a fallback does happen, the report says so:
+
+```yaml
+provider: openai
+fell_back: true
+requested_provider: falcon
+provider_attempts:
+- provider: falcon
+  succeeded: false
+  error_type: ProviderBillingError
+  reason: 402 no credits -- the account is out of credits
+  retryable: false
+- provider: openai
+  succeeded: true
+```
+
+Only failures meaning *this provider cannot do the work* are followed. A 429 or a 5xx says to wait and retry the same provider, not to switch, and an unrecognised failure is not evidence that anyone else would do better. From Python:
+
+```python
+result = client.research("Statins and myopathy", provider="falcon", fallback=True)
+result.provider            # who actually produced it
+result.requested_provider  # who was asked
+result.fell_back           # whether a switch happened
+result.provider_attempts   # each provider tried, and why it failed
+```
+
+See the [Choose a Provider guide](docs/how-to/choose-provider.md#fall-back-to-another-provider) for the full rules.
 
 ### Python Library Usage
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,8 @@ provider_attempts:
 - provider: falcon
   succeeded: false
   error_type: ProviderBillingError
-  reason: 402 no credits -- the account is out of credits
+  status_code: 402
+  remedy: the account is out of credits
   retryable: false
 - provider: openai
   succeeded: true

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ provider_attempts:
   succeeded: true
 ```
 
-`remedy` is our reading of the failure, not the provider's own error text: that text can quote whatever a provider puts in a response body — including, for a rejected key, the key — and these reports get committed, so the raw version stays on the result object and in the logs. Reports and cache entries produced without a fallback gain none of these keys, though the result object always carries `provider_attempts`. Only failures meaning *this provider cannot do the work* are followed. A 429 or a 5xx says to wait and retry the same provider, not to switch, and an unrecognised failure is not evidence that anyone else would do better. From Python:
+`remedy` is our reading of the failure, not the provider's own error text: that text can quote whatever a provider puts in a response body — including, for a rejected key, the key — and these reports get committed, so the raw version stays on the result object and in the logs. A report produced without a fallback gains none of these keys. Cache entries carry them empty, and are written before the provenance is stamped, so a cached answer can never be replayed as a fallback that never happened. Only failures meaning *this provider cannot do the work* are followed. A 429 or a 5xx says to wait and retry the same provider, not to switch, and an unrecognised failure is not evidence that anyone else would do better. From Python:
 
 ```python
 result = client.research("Statins and myopathy", provider="falcon", fallback=True)

--- a/docs/how-to/choose-provider.md
+++ b/docs/how-to/choose-provider.md
@@ -157,7 +157,10 @@ It is **off by default, and deliberately so.** A report records the provider
 that produced it, and downstream curation reads that field: silently swapping
 providers would make those records wrong. So you have to ask for it.
 
-To control the order yourself, name the providers:
+`--fallback` tries the other configured providers in **registration order** —
+the order the client detects them from the environment, which is not a
+preference ranking. Each candidate is a paid account, so when it matters which
+one you spend money on, name them yourself rather than relying on that order:
 
 ```bash
 deep-research-client research "CRISPR delivery mechanisms" \
@@ -168,7 +171,9 @@ deep-research-client research "CRISPR delivery mechanisms" \
 ```
 
 Naming providers *replaces* the automatic ordering rather than adding to it, so
-a configured provider you leave out is never tried.
+a configured provider you leave out is never tried. For a single fallback the
+bare name works too — `fallback="openai"` from Python is the same as
+`fallback=["openai"]`.
 
 ### What gets recorded
 

--- a/docs/how-to/choose-provider.md
+++ b/docs/how-to/choose-provider.md
@@ -251,7 +251,9 @@ its own defaults, and the run says so on stderr when it happens.
 
 **Nothing is written until a provider succeeds.** If every candidate fails, the
 run raises with the last failure and no report, no cache entry, and no partial
-file is left behind.
+file is left behind. Since there is no result, there is no `provider_attempts`
+to read: the raised error is chained to the failure before it, so
+`err.__cause__` shows the previous candidate, and the full trail is in the log.
 
 **A provider you can no longer reach can still answer from its own cache.**
 When a candidate cannot be prepared — its key revoked, say — and *another
@@ -270,6 +272,16 @@ Two more things worth knowing. Cache entries never expire, so a report served
 this way may be arbitrarily old. And nothing falls back when the *first*
 candidate answers from cache; if a later one does, the earlier failures are
 still recorded and the report reads `fell_back: true`, which is accurate.
+
+**This is the one case the report does not record.** When the first candidate
+answers from its own cache, the saved report is identical to an ordinary cache
+hit — `provider: falcon`, `cached: true`, and no `fell_back` or
+`provider_attempts` entry, because nothing fell back and the report really was
+produced by falcon. That the provider was unreachable *this* run is an
+operational fact about the run rather than about the report, so it goes to the
+log and nowhere else. If you need it durably, capture stderr: the run warns
+`Provider falcon cannot do this run: … Serving the report it produced for this
+query earlier`.
 
 ### Trying it without an outage
 

--- a/docs/how-to/choose-provider.md
+++ b/docs/how-to/choose-provider.md
@@ -275,10 +275,13 @@ ENABLE_MOCK_PROVIDER=true deep-research-client research "test" \
   --fallback-provider deeper_med
 ```
 
-`--param error_type=quota` is the one worth running against the rule above:
-a quota failure is the only kind whose remedy embeds a provider-supplied reset
+Swap `error_type=billing` for `error_type=quota` in the **first** command
+above — the one that writes `report.md` — to watch the withholding happen. A
+quota failure is the only kind whose remedy embeds a provider-supplied reset
 time, so the console prints `renews at 3pm, pool quota_pool_7f21` while the
-report keeps only `the plan's usage limit is spent`.
+saved report keeps only `the plan's usage limit is spent`. Running it against
+the `deeper_med` command below instead shows you the console half and no
+report, since that one is fail-closed by design.
 
 Note that `mock` is reached by `--fallback-provider mock` but never by
 `--fallback` on its own: a provider that invents its reports is excluded from

--- a/docs/how-to/choose-provider.md
+++ b/docs/how-to/choose-provider.md
@@ -207,6 +207,14 @@ That text can quote whatever the provider chose to put in a response body —
 including, for a rejected key, the key — and these reports get committed, so
 the raw version stays on the result object and in the logs rather than on disk.
 
+Every key in `provider_attempts` is one the client produces, which is what
+makes the rule checkable by reading the list. A quota error's reset time is
+withheld for the same reason even though it is harmless in itself: it is parsed
+out of provider text, so keeping it would make the rule "ours, except one
+field". The console still prints the provider's own words — an operator
+diagnosing a failed provider needs them, and they are reading their own
+terminal rather than a file someone else committed.
+
 The result *object* is the exception: `requested_provider` and
 `provider_attempts` are always populated, so a library caller serialising a
 result sees them on every run, recording the single provider that answered.

--- a/docs/how-to/choose-provider.md
+++ b/docs/how-to/choose-provider.md
@@ -242,7 +242,7 @@ report, so it is taken only where the failure type is evidence it should be.
 cached report is served and nothing falls back — see *A provider you can no
 longer reach* below.
 
-### Two things to know
+### Things to know
 
 **`--model` and `--param` apply to the first provider only.** They were chosen
 for the provider you named -- a Perplexity model name means nothing to OpenAI,

--- a/docs/how-to/choose-provider.md
+++ b/docs/how-to/choose-provider.md
@@ -280,8 +280,8 @@ above — the one that writes `report.md` — to watch the withholding happen. A
 quota failure is the only kind whose remedy embeds a provider-supplied reset
 time, so the console prints `renews at 3pm, pool quota_pool_7f21` while the
 saved report keeps only `the plan's usage limit is spent`. Running it against
-the `deeper_med` command below instead shows you the console half and no
-report, since that one is fail-closed by design.
+the `deeper_med` command just above shows you the console half and no report,
+since that one is fail-closed by design.
 
 Note that `mock` is reached by `--fallback-provider mock` but never by
 `--fallback` on its own: a provider that invents its reports is excluded from

--- a/docs/how-to/choose-provider.md
+++ b/docs/how-to/choose-provider.md
@@ -157,10 +157,14 @@ It is **off by default, and deliberately so.** A report records the provider
 that produced it, and downstream curation reads that field: silently swapping
 providers would make those records wrong. So you have to ask for it.
 
-`--fallback` tries the other configured providers in **registration order** —
-the order the client detects them from the environment, which is not a
-preference ranking. Each candidate is a paid account, so when it matters which
-one you spend money on, name them yourself rather than relying on that order:
+`--fallback` tries the other configured providers in **registration order**,
+which is a fixed sequence filtered down to whichever you have configured — not
+a preference ranking, and not dependent on how your environment is set up:
+
+    openai, falcon, asta, perplexity, consensus, openscientist, cyberian, claude_code
+
+Each candidate is a paid account, so when it matters which one you spend money
+on, name them yourself rather than relying on that order:
 
 ```bash
 deep-research-client research "CRISPR delivery mechanisms" \
@@ -187,7 +191,8 @@ provider_attempts:
 - provider: falcon
   succeeded: false
   error_type: ProviderBillingError
-  reason: 402 no credits -- the account is out of credits
+  status_code: 402
+  remedy: the account is out of credits
   retryable: false
 - provider: openai
   succeeded: true
@@ -196,6 +201,11 @@ provider_attempts:
 A report that came from the provider you asked for gains none of these fields:
 their presence *is* the finding. The same goes for cache entries, which are
 written before the provenance is stamped.
+
+`remedy` is our reading of the failure, not the provider's own error text.
+That text can quote whatever the provider chose to put in a response body —
+including, for a rejected key, the key — and these reports get committed, so
+the raw version stays on the result object and in the logs rather than on disk.
 
 The result *object* is the exception: `requested_provider` and
 `provider_attempts` are always populated, so a library caller serialising a
@@ -229,7 +239,8 @@ file is left behind.
 
 The mock provider can simulate any of these failures, so you can see the
 behaviour before you rely on it. With a second provider configured, this
-produces a real report and the frontmatter above:
+produces a real report whose frontmatter has the shape shown above, with
+`requested_provider: mock` and whichever provider answered:
 
 ```bash
 ENABLE_MOCK_PROVIDER=true deep-research-client research "test" \

--- a/docs/how-to/choose-provider.md
+++ b/docs/how-to/choose-provider.md
@@ -252,10 +252,16 @@ its own defaults, and the run says so on stderr when it happens.
 **Nothing is written until a provider succeeds.** If every candidate fails, the
 run raises with the last failure and no report, no cache entry, and no partial
 file is left behind. Since there is no result, there is no
-`provider_attempts` on one — so the trail is carried on the error instead:
-`err.provider_attempts` lists every candidate tried, including the one whose
-failure ended the run. `err.__cause__` is left alone, because providers set it
-themselves to the upstream API error.
+`provider_attempts` on one — so the trail is carried on the error instead.
+Read it with `getattr(err, "provider_attempts", ())`: it lists every candidate
+tried, including the one whose failure ended the run, but only when that
+failure is one the client classified. A provider that cannot recognise its own
+SDK error re-raises it bare, and a plain exception has no field to carry a
+trail; the run logs it in that case instead. `err.__cause__` is left alone
+either way, because providers set it themselves to the upstream API error.
+
+The CLI prints the same trail on a run where every candidate failed, so you do
+not need to catch anything to see it.
 
 **A provider you can no longer reach can still answer from its own cache.**
 When a candidate cannot be prepared — its key revoked, say — and *another
@@ -282,11 +288,12 @@ first candidate the saved report is identical to an ordinary cache hit —
 `provider: falcon`, `cached: true`, and no `fell_back` or `provider_attempts`
 entry, because nothing fell back and the report really was produced by falcon.
 At a later one the earlier failures are recorded and `fell_back` is true, but
-the serving candidate is still listed only as having produced the report. That the provider was unreachable *this* run is an
-operational fact about the run rather than about the report, so it goes to the
-log and nowhere else. If you need it durably, capture stderr: the run warns
-`Provider falcon cannot do this run: … Serving the report it produced for this
-query earlier`.
+the serving candidate is still listed only as having produced the report.
+That the provider was unreachable *this* run is an operational fact about
+the run rather than about the report, so it goes to the log and nowhere
+else. If you need it durably, capture stderr: the run
+warns `Provider falcon cannot do this run: … Serving the report it produced
+for this query earlier`.
 
 ### Trying it without an outage
 

--- a/docs/how-to/choose-provider.md
+++ b/docs/how-to/choose-provider.md
@@ -142,6 +142,89 @@ deep-research-client research "Clinical trial evidence for alpha-synuclein targe
   --output synuclein-trials.md
 ```
 
+## Fall Back to Another Provider
+
+A run can fail for reasons no retry fixes: an account out of credits, a spent
+plan allowance, a rejected or missing key. `--fallback` lets a different
+provider take the work instead.
+
+```bash
+deep-research-client research "Statins and myopathy" \
+  --provider falcon --fallback --output report.md
+```
+
+It is **off by default, and deliberately so.** A report records the provider
+that produced it, and downstream curation reads that field: silently swapping
+providers would make those records wrong. So you have to ask for it.
+
+To control the order yourself, name the providers:
+
+```bash
+deep-research-client research "CRISPR delivery mechanisms" \
+  --provider falcon \
+  --fallback-provider openai \
+  --fallback-provider perplexity \
+  --output report.md
+```
+
+Naming providers *replaces* the automatic ordering rather than adding to it, so
+a configured provider you leave out is never tried.
+
+### What gets recorded
+
+A report produced by a fallback says so in its frontmatter, and says why:
+
+```yaml
+provider: openai
+fell_back: true
+requested_provider: falcon
+provider_attempts:
+- provider: falcon
+  succeeded: false
+  error_type: ProviderBillingError
+  reason: 402 no credits -- the account is out of credits
+  retryable: false
+- provider: openai
+  succeeded: true
+```
+
+A report that came from the provider you asked for gains none of these fields:
+their presence *is* the finding.
+
+### Which failures are followed
+
+| Failure | Falls back? | Why |
+|---------|-------------|-----|
+| No credits (402), spent quota, rejected key (401/403), not configured | Yes | This provider cannot do the work; another might |
+| Rate limited (429) | No | The same provider will take it shortly -- wait and retry |
+| Server error (5xx) | No | A temporary fault, not a reason to change who answers |
+| Anything unrecognised | No | An unexplained failure is not evidence another provider would do better |
+
+The last row is the conservative default: a fallback changes who produced your
+report, so it is taken only where the failure type is evidence it should be.
+
+### Two things to know
+
+**`--model` and `--param` apply to the first provider only.** They were chosen
+for the provider you named -- a Perplexity model name means nothing to OpenAI,
+and an unknown parameter is a hard error. A fallback provider therefore runs on
+its own defaults, and the run says so on stderr when it happens.
+
+**Nothing is written until a provider succeeds.** If every candidate fails, the
+run raises with the last failure and no report, no cache entry, and no partial
+file is left behind.
+
+### Trying it without an outage
+
+The mock provider can simulate any of these failures, so you can see the
+behaviour before you rely on it:
+
+```bash
+ENABLE_MOCK_PROVIDER=true deep-research-client research "test" \
+  --provider mock --param error_type=billing \
+  --fallback-provider deeper_med
+```
+
 ## Check Available Models
 
 List all available models and their characteristics:

--- a/docs/how-to/choose-provider.md
+++ b/docs/how-to/choose-provider.md
@@ -251,9 +251,11 @@ its own defaults, and the run says so on stderr when it happens.
 
 **Nothing is written until a provider succeeds.** If every candidate fails, the
 run raises with the last failure and no report, no cache entry, and no partial
-file is left behind. Since there is no result, there is no `provider_attempts`
-to read: the raised error is chained to the failure before it, so
-`err.__cause__` shows the previous candidate, and the full trail is in the log.
+file is left behind. Since there is no result, there is no
+`provider_attempts` on one — so the trail is carried on the error instead:
+`err.provider_attempts` lists every candidate tried, including the one whose
+failure ended the run. `err.__cause__` is left alone, because providers set it
+themselves to the upstream API error.
 
 **A provider you can no longer reach can still answer from its own cache.**
 When a candidate cannot be prepared — its key revoked, say — and *another
@@ -271,13 +273,16 @@ exactly as it always did — which is the property the narrow rule protects.
 Two more things worth knowing. Cache entries never expire, so a report served
 this way may be arbitrarily old. And nothing falls back when the *first*
 candidate answers from cache; if a later one does, the earlier failures are
-still recorded and the report reads `fell_back: true`, which is accurate.
+still recorded and the report reads `fell_back: true` — accurate about them,
+though silent about the serving candidate, as below.
 
-**This is the one case the report does not record.** When the first candidate
-answers from its own cache, the saved report is identical to an ordinary cache
-hit — `provider: falcon`, `cached: true`, and no `fell_back` or
-`provider_attempts` entry, because nothing fell back and the report really was
-produced by falcon. That the provider was unreachable *this* run is an
+**This is the case the report does not record.** When a candidate answers from
+its own cache, nothing marks that it could not be reached this run. At the
+first candidate the saved report is identical to an ordinary cache hit —
+`provider: falcon`, `cached: true`, and no `fell_back` or `provider_attempts`
+entry, because nothing fell back and the report really was produced by falcon.
+At a later one the earlier failures are recorded and `fell_back` is true, but
+the serving candidate is still listed only as having produced the report. That the provider was unreachable *this* run is an
 operational fact about the run rather than about the report, so it goes to the
 log and nowhere else. If you need it durably, capture stderr: the run warns
 `Provider falcon cannot do this run: … Serving the report it produced for this

--- a/docs/how-to/choose-provider.md
+++ b/docs/how-to/choose-provider.md
@@ -199,8 +199,7 @@ provider_attempts:
 ```
 
 A report that came from the provider you asked for gains none of these fields:
-their presence *is* the finding. The same goes for cache entries, which are
-written before the provenance is stamped.
+their presence *is* the finding.
 
 `remedy` is our reading of the failure, not the provider's own error text.
 That text can quote whatever the provider chose to put in a response body —
@@ -215,10 +214,17 @@ field". The console still prints the provider's own words — an operator
 diagnosing a failed provider needs them, and they are reading their own
 terminal rather than a file someone else committed.
 
-The result *object* is the exception: `requested_provider` and
-`provider_attempts` are always populated, so a library caller serialising a
-result sees them on every run, recording the single provider that answered.
-`fell_back` is what distinguishes the two cases.
+Two other places behave differently, and it is worth being precise about how:
+
+- **Cache entries** do carry `requested_provider` and `provider_attempts`, as
+  `null` and `[]`. Nothing from a run is stored in them — the entry is written
+  before the provenance is stamped, so a cached answer can never be replayed as
+  a fallback that never happened — but the keys themselves are present.
+- **The result object** always populates both, so a library caller serialising
+  a result sees them on every run, recording the single provider that answered.
+  `fell_back` is a property rather than a stored field, so it is *not* in
+  `model_dump()`; read it off the object, or derive it from
+  `provider_attempts`.
 
 ### Which failures are followed
 
@@ -268,6 +274,11 @@ ENABLE_MOCK_PROVIDER=true deep-research-client research "test" \
   --provider mock --param error_type=billing \
   --fallback-provider deeper_med
 ```
+
+`--param error_type=quota` is the one worth running against the rule above:
+a quota failure is the only kind whose remedy embeds a provider-supplied reset
+time, so the console prints `renews at 3pm, pool quota_pool_7f21` while the
+report keeps only `the plan's usage limit is spent`.
 
 Note that `mock` is reached by `--fallback-provider mock` but never by
 `--fallback` on its own: a provider that invents its reports is excluded from

--- a/docs/how-to/choose-provider.md
+++ b/docs/how-to/choose-provider.md
@@ -230,7 +230,7 @@ Two other places behave differently, and it is worth being precise about how:
 
 | Failure | Falls back? | Why |
 |---------|-------------|-----|
-| No credits (402), spent quota, rejected key (401/403), not configured | Yes[^cache] | This provider cannot do the work; another might |
+| No credits (402), spent quota, rejected key (401/403), not configured | Yes* | This provider cannot do the work; another might |
 | Rate limited (429) | No | The same provider will take it shortly -- wait and retry |
 | Server error (5xx) | No | A temporary fault, not a reason to change who answers |
 | Anything unrecognised | No | An unexplained failure is not evidence another provider would do better |
@@ -238,9 +238,9 @@ Two other places behave differently, and it is worth being precise about how:
 The last row is the conservative default: a fallback changes who produced your
 report, so it is taken only where the failure type is evidence it should be.
 
-[^cache]: Unless that provider has already answered this query — its own cached
-report is served instead and nothing falls back. See *A provider you can no
-longer reach* above.
+\* Unless that provider has already answered this query, in which case its own
+cached report is served and nothing falls back — see *A provider you can no
+longer reach* below.
 
 ### Two things to know
 
@@ -254,13 +254,22 @@ run raises with the last failure and no report, no cache entry, and no partial
 file is left behind.
 
 **A provider you can no longer reach can still answer from its own cache.**
-When a fallback is requested and a candidate cannot be prepared — its key
-revoked, say — that candidate's cache is consulted before the next provider is
-billed for a report you already hold. You get the original provider's report,
-attributed to it, with no fallback recorded, because none happened. Two things
-follow: cache entries never expire, so such a report may be old; and this
-applies only where a later candidate would otherwise be called, so without
-`--fallback` an unconfigured provider still fails exactly as it always did.
+When a candidate cannot be prepared — its key revoked, say — and *another
+candidate remains*, that candidate's cache is consulted before the next
+provider is called. You get the original provider's report, attributed to it,
+and no second provider is billed.
+
+The rule is "another candidate remains", not "someone would otherwise be
+billed", and the two come apart: `--fallback-provider deeper_med` unlocks the
+read even though that stub could never be billed, while `--provider falcon
+--fallback` with nothing else configured does not, because falcon is then the
+only candidate. Without any fallback flag an unconfigured provider fails
+exactly as it always did — which is the property the narrow rule protects.
+
+Two more things worth knowing. Cache entries never expire, so a report served
+this way may be arbitrarily old. And nothing falls back when the *first*
+candidate answers from cache; if a later one does, the earlier failures are
+still recorded and the report reads `fell_back: true`, which is accurate.
 
 ### Trying it without an outage
 

--- a/docs/how-to/choose-provider.md
+++ b/docs/how-to/choose-provider.md
@@ -189,7 +189,13 @@ provider_attempts:
 ```
 
 A report that came from the provider you asked for gains none of these fields:
-their presence *is* the finding.
+their presence *is* the finding. The same goes for cache entries, which are
+written before the provenance is stamped.
+
+The result *object* is the exception: `requested_provider` and
+`provider_attempts` are always populated, so a library caller serialising a
+result sees them on every run, recording the single provider that answered.
+`fell_back` is what distinguishes the two cases.
 
 ### Which failures are followed
 
@@ -217,13 +223,32 @@ file is left behind.
 ### Trying it without an outage
 
 The mock provider can simulate any of these failures, so you can see the
-behaviour before you rely on it:
+behaviour before you rely on it. With a second provider configured, this
+produces a real report and the frontmatter above:
+
+```bash
+ENABLE_MOCK_PROVIDER=true deep-research-client research "test" \
+  --provider mock --param error_type=billing --fallback \
+  --output report.md
+```
+
+If you have no other provider configured, the run has nowhere to go and stops
+with the mock's simulated billing failure -- which is the fail-closed behaviour,
+not a bug. To watch the switch happen without configuring anything, name
+`deeper_med` as the fallback: it is a permanently unavailable stub, so the run
+still ends in an error and writes no report, but the log shows the fallback
+being taken and each provider explaining itself:
 
 ```bash
 ENABLE_MOCK_PROVIDER=true deep-research-client research "test" \
   --provider mock --param error_type=billing \
   --fallback-provider deeper_med
 ```
+
+Note that `mock` is reached by `--fallback-provider mock` but never by
+`--fallback` on its own: a provider that invents its reports is excluded from
+the automatic ordering, so a real run that runs out of credits fails rather
+than quietly handing you a fabricated report.
 
 ## Check Available Models
 

--- a/docs/how-to/choose-provider.md
+++ b/docs/how-to/choose-provider.md
@@ -230,13 +230,17 @@ Two other places behave differently, and it is worth being precise about how:
 
 | Failure | Falls back? | Why |
 |---------|-------------|-----|
-| No credits (402), spent quota, rejected key (401/403), not configured | Yes | This provider cannot do the work; another might |
+| No credits (402), spent quota, rejected key (401/403), not configured | Yes[^cache] | This provider cannot do the work; another might |
 | Rate limited (429) | No | The same provider will take it shortly -- wait and retry |
 | Server error (5xx) | No | A temporary fault, not a reason to change who answers |
 | Anything unrecognised | No | An unexplained failure is not evidence another provider would do better |
 
 The last row is the conservative default: a fallback changes who produced your
 report, so it is taken only where the failure type is evidence it should be.
+
+[^cache]: Unless that provider has already answered this query — its own cached
+report is served instead and nothing falls back. See *A provider you can no
+longer reach* above.
 
 ### Two things to know
 
@@ -248,6 +252,15 @@ its own defaults, and the run says so on stderr when it happens.
 **Nothing is written until a provider succeeds.** If every candidate fails, the
 run raises with the last failure and no report, no cache entry, and no partial
 file is left behind.
+
+**A provider you can no longer reach can still answer from its own cache.**
+When a fallback is requested and a candidate cannot be prepared — its key
+revoked, say — that candidate's cache is consulted before the next provider is
+billed for a report you already hold. You get the original provider's report,
+attributed to it, with no fallback recorded, because none happened. Two things
+follow: cache entries never expire, so such a report may be old; and this
+applies only where a later candidate would otherwise be called, so without
+`--fallback` an unconfigured provider still fails exactly as it always did.
 
 ### Trying it without an outage
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -31,6 +31,8 @@ deep-research-client research [OPTIONS] [QUERY]
 |--------|-------------|
 | `--provider TEXT` | Provider to use: openai, edison, perplexity, consensus, cyberian |
 | `--model TEXT` | Model to use (overrides provider default) |
+| `--fallback` | If the chosen provider cannot do the work, try the other configured providers instead (off by default) |
+| `--fallback-provider TEXT` | Provider to fall back to, in preference order (repeatable); implies `--fallback` |
 | `--output PATH` | Output file path (prints to stdout if not provided) |
 | `--no-cache` | Disable caching for this query |
 | `--separate-citations PATH` | Save citations to separate file |
@@ -120,6 +122,13 @@ deep-research-client research "CFAP300 gene function" \
 deep-research-client research "AI" \
   --base-url https://api.example.com \
   --api-key-env CUSTOM_API_KEY
+
+# Let another provider take over if this one is out of credits
+deep-research-client research "Statins and myopathy" --provider falcon --fallback
+
+# Name the fallback order explicitly
+deep-research-client research "CRISPR delivery" \
+  --provider falcon --fallback-provider openai --fallback-provider perplexity
 
 # Check every cited identifier before trusting the report
 deep-research-client research "Statins and myopathy risk" \

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -31,7 +31,7 @@ deep-research-client research [OPTIONS] [QUERY]
 |--------|-------------|
 | `--provider TEXT` | Provider to use: openai, edison, perplexity, consensus, cyberian |
 | `--model TEXT` | Model to use (overrides provider default) |
-| `--fallback` | If the chosen provider cannot do the work, try the other configured providers instead (off by default) |
+| `--fallback` | If the chosen provider cannot do the work, try the other configured providers instead, in registration order (off by default) |
 | `--fallback-provider TEXT` | Provider to fall back to, in preference order (repeatable); implies `--fallback` |
 | `--output PATH` | Output file path (prints to stdout if not provided) |
 | `--no-cache` | Disable caching for this query |

--- a/src/deep_research_client/__init__.py
+++ b/src/deep_research_client/__init__.py
@@ -5,12 +5,14 @@ except ImportError:  # pragma: no cover
     __version_tuple__ = (0, 0, 0)
 
 from .client import DeepResearchClient
-from .models import ResearchResult, ProviderConfig, CacheConfig, QueryMetadata, EditHistoryEntry, ProviderHealth
+from .models import ResearchResult, ProviderAttempt, ProviderConfig, CacheConfig, QueryMetadata, EditHistoryEntry, ProviderHealth
 from .exceptions import (
     MAX_DETAIL_CHARS,
     MIN_DETAIL_CHARS,
     MAX_RESET_CHARS,
     truncate_detail,
+    FALLBACK_WORTHY_ERRORS,
+    is_fallback_worthy,
     ProviderError,
     ProviderAuthError,
     ProviderBillingError,
@@ -59,6 +61,7 @@ from .validation import (
 __all__ = [
     "DeepResearchClient",
     "ResearchResult",
+    "ProviderAttempt",
     "ProviderConfig",
     "CacheConfig",
     "QueryMetadata",
@@ -68,6 +71,8 @@ __all__ = [
     "MIN_DETAIL_CHARS",
     "MAX_RESET_CHARS",
     "truncate_detail",
+    "FALLBACK_WORTHY_ERRORS",
+    "is_fallback_worthy",
     "ProviderError",
     "ProviderAuthError",
     "ProviderBillingError",

--- a/src/deep_research_client/cli.py
+++ b/src/deep_research_client/cli.py
@@ -1067,6 +1067,17 @@ def research(
 
     except ValueError as exc:
         logger.error(f"Error: {exc}")
+        # The trail is on the error when every candidate failed. Without this
+        # the CLI says more about who was tried when a fallback *worked* than
+        # when it did not, which is backwards: the total failure is where an
+        # operator needs it. getattr, because an unclassified failure carries
+        # no such attribute -- the client logs the trail itself in that case.
+        attempts = getattr(exc, "provider_attempts", ())
+        if attempts:
+            logger.error(
+                "Providers tried:\n  %s",
+                "\n  ".join(attempt.summary() for attempt in attempts),
+            )
         raise typer.Exit(1)
     except OSError as exc:
         logger.error(f"Filesystem error: {exc}")

--- a/src/deep_research_client/cli.py
+++ b/src/deep_research_client/cli.py
@@ -875,13 +875,30 @@ def research(
         _echo_no_providers_message()
         raise typer.Exit(1)
 
+    # An explicit list is an ordering instruction, so it replaces the
+    # automatic one rather than adding to it.
+    fallback_request: Union[bool, List[str]] = (
+        list(fallback_provider) if fallback_provider else fallback
+    )
+
     # Show available providers
     if provider:
         if provider not in available_providers:
-            logger.error(
-                f"Provider '{provider}' not available. Available: {', '.join(available_providers)}")
-            raise typer.Exit(1)
-        logger.info(f"Using provider: {provider}")
+            if not fallback_request:
+                logger.error(
+                    f"Provider '{provider}' not available. Available: {', '.join(available_providers)}")
+                raise typer.Exit(1)
+            # "Not configured" is one of the failures a fallback exists to
+            # handle, and the client treats it as one. Ending the run here
+            # would make the CLI refuse what the library allows, and would
+            # drop the provider from the trail the report is supposed to
+            # carry. If nothing else can take the work either, the client
+            # raises and the run still fails -- with every attempt recorded.
+            logger.warning(
+                f"Provider '{provider}' is not configured; continuing because a fallback was requested"
+            )
+        else:
+            logger.info(f"Using provider: {provider}")
     else:
         logger.info(f"Available providers: {', '.join(available_providers)}")
         logger.info(f"Using: {available_providers[0]}")
@@ -961,11 +978,6 @@ def research(
     try:
         # Perform research
         logger.debug(f"Starting research with query: {query[:100]}...")
-        # An explicit list is an ordering instruction, so it replaces the
-        # automatic one rather than adding to it.
-        fallback_request: Union[bool, List[str]] = (
-            list(fallback_provider) if fallback_provider else fallback
-        )
         result = client.research(
             query,
             provider,

--- a/src/deep_research_client/cli.py
+++ b/src/deep_research_client/cli.py
@@ -884,7 +884,14 @@ def research(
     # Show available providers
     if provider:
         if provider not in available_providers:
-            if not fallback_request:
+            # A name that is not a provider at all is a typo, and the remedy
+            # for a typo is the list of names that exist. Standing down for one
+            # would replace that list with a bare "not found" from inside the
+            # loop, and assert on the way past that the provider was merely
+            # unconfigured -- which is the error 89e5840 rejected in the other
+            # direction. The client answers the distinction; asking it here is
+            # what keeps the two surfaces from drifting.
+            if not fallback_request or not client.knows_provider(provider):
                 logger.error(
                     f"Provider '{provider}' not available. Available: {', '.join(available_providers)}")
                 raise typer.Exit(1)

--- a/src/deep_research_client/cli.py
+++ b/src/deep_research_client/cli.py
@@ -985,6 +985,14 @@ def research(
         # The client already warned that someone else produced this. Restating
         # it here made one fallback emit the same sentence twice; what the CLI
         # adds is the trail, so that is all it prints.
+        #
+        # summary() carries the provider's own error text, which the *report*
+        # deliberately withholds. That difference is intended and was weighed:
+        # the console is where an operator diagnoses a failed provider, and
+        # withholding it there costs them the evidence while protecting
+        # nothing the raised error did not already print. A committed file is
+        # read by people who were not running the command, which is the
+        # distinction -- not secrecy.
         if result.fell_back:
             logger.warning(
                 "Providers tried:\n  %s",

--- a/src/deep_research_client/cli.py
+++ b/src/deep_research_client/cli.py
@@ -608,7 +608,7 @@ def research(
     model: Annotated[Optional[str], typer.Option(
         help="Model to use for the provider (overrides provider default)")] = None,
     fallback: Annotated[bool, typer.Option(
-        "--fallback", help="If the chosen provider cannot do the work (no credits, spent quota, rejected or missing credentials), try the other configured providers instead. Off by default: the report records which provider actually produced it")] = False,
+        "--fallback", help="If the chosen provider cannot do the work (no credits, spent quota, rejected or missing credentials), try the other configured providers instead, in registration order. Off by default: the report records which provider actually produced it. Use --fallback-provider when the order matters")] = False,
     fallback_provider: Annotated[Optional[List[str]], typer.Option(
         "--fallback-provider", help="Provider to fall back to, in preference order (repeatable). Implies --fallback and replaces its automatic ordering")] = None,
     output: Annotated[Optional[Path], typer.Option(

--- a/src/deep_research_client/cli.py
+++ b/src/deep_research_client/cli.py
@@ -982,12 +982,12 @@ def research(
         else:
             logger.info(f"Research completed using {result.provider}")
 
-        # Warn, not inform: the report came from someone other than the
-        # provider asked for, and that changes what the report means.
+        # The client already warned that someone else produced this. Restating
+        # it here made one fallback emit the same sentence twice; what the CLI
+        # adds is the trail, so that is all it prints.
         if result.fell_back:
             logger.warning(
-                "Fell back to %s. Providers tried:\n  %s",
-                result.provider,
+                "Providers tried:\n  %s",
                 "\n  ".join(attempt.summary() for attempt in result.provider_attempts),
             )
 

--- a/src/deep_research_client/cli.py
+++ b/src/deep_research_client/cli.py
@@ -9,7 +9,7 @@ import os
 import re
 import typer
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, List
+from typing import TYPE_CHECKING, Optional, List, Union
 from typing_extensions import Annotated
 
 if TYPE_CHECKING:  # pragma: no cover - imports only for type checking
@@ -607,6 +607,10 @@ def research(
         help="Specific provider to use (openai, falcon, asta, perplexity, consensus, openscientist, claude_code, mock)")] = None,
     model: Annotated[Optional[str], typer.Option(
         help="Model to use for the provider (overrides provider default)")] = None,
+    fallback: Annotated[bool, typer.Option(
+        "--fallback", help="If the chosen provider cannot do the work (no credits, spent quota, rejected or missing credentials), try the other configured providers instead. Off by default: the report records which provider actually produced it")] = False,
+    fallback_provider: Annotated[Optional[List[str]], typer.Option(
+        "--fallback-provider", help="Provider to fall back to, in preference order (repeatable). Implies --fallback and replaces its automatic ordering")] = None,
     output: Annotated[Optional[Path], typer.Option(
         help="Output file path (prints to stdout if not provided)")] = None,
     no_cache: Annotated[bool, typer.Option(
@@ -692,6 +696,12 @@ def research(
 
       # Use provider-specific parameters
       deep-research-client research "Medical research" --provider perplexity --param reasoning_effort=high --param search_recency_filter=week
+
+      # Let another provider take over if this one is out of credits
+      deep-research-client research "Statins and myopathy" --provider falcon --fallback
+
+      # Name the fallback order explicitly
+      deep-research-client research "CRISPR delivery" --provider falcon --fallback-provider openai --fallback-provider perplexity
 
       # Use template with variables
       deep-research-client research --template research_template.md --var topic="machine learning" --var focus="healthcare applications"
@@ -951,6 +961,11 @@ def research(
     try:
         # Perform research
         logger.debug(f"Starting research with query: {query[:100]}...")
+        # An explicit list is an ordering instruction, so it replaces the
+        # automatic one rather than adding to it.
+        fallback_request: Union[bool, List[str]] = (
+            list(fallback_provider) if fallback_provider else fallback
+        )
         result = client.research(
             query,
             provider,
@@ -958,6 +973,7 @@ def research(
             effective_options.model,
             provider_params,
             metadata,
+            fallback_request,
         )
 
         # Show cache status
@@ -965,6 +981,15 @@ def research(
             logger.info("Result retrieved from cache")
         else:
             logger.info(f"Research completed using {result.provider}")
+
+        # Warn, not inform: the report came from someone other than the
+        # provider asked for, and that changes what the report means.
+        if result.fell_back:
+            logger.warning(
+                "Fell back to %s. Providers tried:\n  %s",
+                result.provider,
+                "\n  ".join(attempt.summary() for attempt in result.provider_attempts),
+            )
 
         # Determine if we're separating citations
         should_separate_citations = separate_citations is not None

--- a/src/deep_research_client/client.py
+++ b/src/deep_research_client/client.py
@@ -353,9 +353,20 @@ class DeepResearchClient:
         Raises:
             ValueError: If there is nothing at all to try.
         """
-        if isinstance(fallback, bool):
+        if isinstance(fallback, str):
+            # A Sequence[str] accepts a str, and list("openai") would quietly
+            # become six one-letter providers. The singular form is the obvious
+            # thing to reach for next to a list, so honour it.
+            extra = [fallback]
+        elif isinstance(fallback, bool):
             extra = (
-                [candidate.name for candidate in self.registry.get_available_providers()]
+                [
+                    candidate.name
+                    for candidate in self.registry.get_available_providers()
+                    # A provider that invents its reports is not a stand-in for
+                    # one that does the work. Name it and it is honoured.
+                    if candidate.produces_real_reports
+                ]
                 if fallback
                 else []
             )
@@ -364,6 +375,22 @@ class DeepResearchClient:
             # unavailable: each one then reports why it could not be used,
             # rather than vanishing from the trail without explanation.
             extra = list(fallback)
+
+        # Names are checked before any provider is called. A typo found
+        # mid-run would abort after the first provider had already been paid
+        # for, never reach the good candidate behind it, and replace the
+        # failure that started the fallback with a bare "not found".
+        unknown = [
+            name
+            for name in extra
+            if name not in PROVIDER_CLASS_PATHS and self.registry.get_provider(name) is None
+        ]
+        if unknown:
+            raise ValueError(
+                f"Provider '{unknown[0]}' not found"
+                if len(unknown) == 1
+                else f"Providers not found: {', '.join(unknown)}"
+            )
 
         if provider:
             ordered = [provider]
@@ -428,6 +455,7 @@ class DeepResearchClient:
         exc: BaseException,
         model: Optional[str],
         provider_params: Optional[dict],
+        overridden_provider: str,
     ) -> None:
         """Say which provider is taking over, and what is being dropped to do it.
 
@@ -437,6 +465,10 @@ class DeepResearchClient:
             exc: The failure that ended the previous attempt.
             model: Model override the caller asked for, if any.
             provider_params: Provider-specific parameters the caller asked for.
+            overridden_provider: The one candidate the overrides were applied
+                to. Not the same as ``failed_provider`` past the first hop,
+                where the provider that just failed had no overrides either --
+                and a message about provenance must not assert otherwise.
         """
         logger.warning(
             "Provider %s cannot do this run: %s. Falling back to %s",
@@ -450,7 +482,7 @@ class DeepResearchClient:
         if dropped:
             logger.warning(
                 "%s runs on its own defaults: %s applied to %s, not to it",
-                next_provider, " and ".join(dropped), failed_provider,
+                next_provider, " and ".join(dropped), overridden_provider,
             )
 
     @staticmethod
@@ -575,7 +607,8 @@ class DeepResearchClient:
                     raise
                 failed.append(ProviderAttempt.from_exception(candidate, exc))
                 self._warn_falling_back(
-                    candidate, candidates[position + 1], exc, model, provider_params
+                    candidate, candidates[position + 1], exc, model,
+                    provider_params, candidates[0],
                 )
                 continue
 
@@ -605,7 +638,8 @@ class DeepResearchClient:
                     raise
                 failed.append(ProviderAttempt.from_exception(candidate, exc))
                 self._warn_falling_back(
-                    candidate, candidates[position + 1], exc, model, provider_params
+                    candidate, candidates[position + 1], exc, model,
+                    provider_params, candidates[0],
                 )
                 continue
 

--- a/src/deep_research_client/client.py
+++ b/src/deep_research_client/client.py
@@ -338,20 +338,23 @@ class DeepResearchClient:
     def _fallback_candidates(
         self,
         provider: Optional[str],
-        fallback: Union[bool, Sequence[str]],
+        fallback: Union[bool, str, Sequence[str]],
     ) -> list[str]:
         """Work out which providers to try, in order.
 
         Args:
             provider: Provider the caller named, if any.
             fallback: False for no fallback, True to fall back to whatever else
-                is available, or an explicit ordered list of provider names.
+                is available, or an ordered list of provider names. A single
+                name may be given as a bare string.
 
         Returns:
             Provider names to try, most-preferred first, without duplicates.
+            With True, the automatic ones follow registration order.
 
         Raises:
-            ValueError: If there is nothing at all to try.
+            ValueError: If a named fallback provider does not exist, or there
+                is nothing at all to try.
         """
         if isinstance(fallback, str):
             # A Sequence[str] accepts a str, and list("openai") would quietly
@@ -498,6 +501,10 @@ class DeepResearchClient:
         describe *this* run, and replaying them out of a cache file would
         credit a later run with a fallback that never happened.
 
+        Announcing the fallback is part of stamping it rather than a separate
+        step at each return, so a path that returns a result cannot forget to
+        mention that someone else produced it -- which the cache-hit path did.
+
         Args:
             result: The result to stamp.
             requested: Provider the caller named, if any.
@@ -509,6 +516,11 @@ class DeepResearchClient:
             *failed,
             ProviderAttempt(provider=used, succeeded=True),
         ]
+        if result.fell_back:
+            logger.warning(
+                "Report produced by %s, not the provider first tried (%s)",
+                used, failed[0].provider,
+            )
 
     def research(
         self,
@@ -518,7 +530,7 @@ class DeepResearchClient:
         model: Optional[str] = None,
         provider_params: Optional[dict] = None,
         metadata: Optional[dict] = None,
-        fallback: Union[bool, Sequence[str]] = False,
+        fallback: Union[bool, str, Sequence[str]] = False,
     ) -> ResearchResult:
         """Perform research on the given query.
 
@@ -531,8 +543,10 @@ class DeepResearchClient:
             metadata: Publication-style metadata (title, abstract, keywords, author, contributors)
             fallback: Opt in to trying another provider when this one cannot do
                 the work. False (the default) never switches providers. True
-                falls back to whatever else is available. A list names the
-                providers to try, in order.
+                falls back to whatever else is available, in registration
+                order, excluding providers that do not do real research. A
+                list -- or a bare string, for one -- names them explicitly, in
+                preference order, and replaces the automatic ordering.
 
         Returns:
             ResearchResult with markdown content and citations
@@ -563,7 +577,7 @@ class DeepResearchClient:
         model: Optional[str] = None,
         provider_params: Optional[dict] = None,
         metadata: Optional[dict] = None,
-        fallback: Union[bool, Sequence[str]] = False,
+        fallback: Union[bool, str, Sequence[str]] = False,
     ) -> ResearchResult:
         """Async version of research method.
 
@@ -694,11 +708,6 @@ class DeepResearchClient:
             # After caching, so that which providers this run tried never
             # becomes part of what a later run reads back.
             self._record_provenance(result, provider, failed, research_provider.name)
-            if result.fell_back:
-                logger.warning(
-                    "Report produced by %s, not the provider first tried (%s)",
-                    result.provider, failed[0].provider,
-                )
             return result
 
         # Unreachable: _fallback_candidates never returns an empty list, and the

--- a/src/deep_research_client/client.py
+++ b/src/deep_research_client/client.py
@@ -10,7 +10,7 @@ from collections.abc import Sequence
 from typing import Any, Optional, Union
 
 from .cache import CacheManager
-from .exceptions import ProviderNotConfiguredError, is_fallback_worthy
+from .exceptions import ProviderError, ProviderNotConfiguredError, is_fallback_worthy
 from .models import (
     ResearchResult,
     ProviderAttempt,
@@ -500,6 +500,29 @@ class DeepResearchClient:
             )
 
     @staticmethod
+    def _attach_trail(
+        exc: BaseException, failed: list[ProviderAttempt], candidate: str
+    ) -> None:
+        """Record every provider tried on the failure that ends the run.
+
+        With no result there is no ``provider_attempts`` to read, which is
+        exactly the case a caller most wants it. This puts the trail on the
+        exception instead -- including the candidate whose failure is being
+        raised, so the list is the whole run and not everything before it.
+
+        Args:
+            exc: The failure about to be re-raised.
+            failed: Attempts that failed earlier, in order.
+            candidate: The provider whose failure ends the run.
+        """
+        if not failed or not isinstance(exc, ProviderError):
+            return
+        exc.provider_attempts = (
+            *failed,
+            ProviderAttempt.from_exception(candidate, exc),
+        )
+
+    @staticmethod
     def _record_provenance(
         result: ResearchResult,
         requested: Optional[str],
@@ -607,12 +630,6 @@ class DeepResearchClient:
 
         candidates = self._fallback_candidates(provider, fallback)
         failed: list[ProviderAttempt] = []
-        # Kept alongside `failed` so the run that exhausts every candidate can
-        # chain rather than discard: each earlier `except` exits via `continue`,
-        # so by the time the last one raises it is no longer being handled and
-        # __context__ is None. Without this a caller sees the final failure and
-        # has no evidence the others were tried.
-        last_failure: Optional[BaseException] = None
 
         async def serve_cached(
             candidate: str,
@@ -684,8 +701,10 @@ class DeepResearchClient:
                 )
             except Exception as exc:
                 if last or not is_fallback_worthy(exc):
-                    if last_failure is not None:
-                        raise exc from last_failure
+                    # Carry the trail out on the exception, then re-raise bare:
+                    # same object, same type, same traceback, and __cause__
+                    # left to whoever set it.
+                    self._attach_trail(exc, failed, candidate)
                     raise
                 # Reading a report off disk needs no credential, so a
                 # provider we can no longer reach can still serve one it
@@ -704,7 +723,6 @@ class DeepResearchClient:
                 if served is not None:
                     return served
                 failed.append(ProviderAttempt.from_exception(candidate, exc))
-                last_failure = exc
                 self._warn_falling_back(
                     candidate, candidates[position + 1], exc, model,
                     provider_params, candidates[0],
@@ -723,11 +741,12 @@ class DeepResearchClient:
                 result = await research_provider.research(query)
             except Exception as exc:
                 if last or not is_fallback_worthy(exc):
-                    if last_failure is not None:
-                        raise exc from last_failure
+                    # Carry the trail out on the exception, then re-raise bare:
+                    # same object, same type, same traceback, and __cause__
+                    # left to whoever set it.
+                    self._attach_trail(exc, failed, candidate)
                     raise
                 failed.append(ProviderAttempt.from_exception(candidate, exc))
-                last_failure = exc
                 self._warn_falling_back(
                     candidate, candidates[position + 1], exc, model,
                     provider_params, candidates[0],

--- a/src/deep_research_client/client.py
+++ b/src/deep_research_client/client.py
@@ -6,11 +6,18 @@ import logging
 import os
 import time
 from datetime import datetime
-from typing import Any, Optional
+from collections.abc import Sequence
+from typing import Any, Optional, Union
 
 from .cache import CacheManager
-from .exceptions import ProviderNotConfiguredError
-from .models import ResearchResult, ProviderConfig, CacheConfig, QueryMetadata
+from .exceptions import ProviderNotConfiguredError, is_fallback_worthy
+from .models import (
+    ResearchResult,
+    ProviderAttempt,
+    ProviderConfig,
+    CacheConfig,
+    QueryMetadata,
+)
 from .providers import ProviderRegistry, ResearchProvider
 from .provider_params import BaseProviderParams, create_provider_params
 
@@ -328,6 +335,149 @@ class DeepResearchClient:
 
         return effective_params or None
 
+    def _fallback_candidates(
+        self,
+        provider: Optional[str],
+        fallback: Union[bool, Sequence[str]],
+    ) -> list[str]:
+        """Work out which providers to try, in order.
+
+        Args:
+            provider: Provider the caller named, if any.
+            fallback: False for no fallback, True to fall back to whatever else
+                is available, or an explicit ordered list of provider names.
+
+        Returns:
+            Provider names to try, most-preferred first, without duplicates.
+
+        Raises:
+            ValueError: If there is nothing at all to try.
+        """
+        if isinstance(fallback, bool):
+            extra = (
+                [candidate.name for candidate in self.registry.get_available_providers()]
+                if fallback
+                else []
+            )
+        else:
+            # An explicit list is an instruction, so names are kept even when
+            # unavailable: each one then reports why it could not be used,
+            # rather than vanishing from the trail without explanation.
+            extra = list(fallback)
+
+        if provider:
+            ordered = [provider]
+        else:
+            first_available = self.registry.get_first_available()
+            ordered = [first_available.name] if first_available else []
+
+        for name in extra:
+            if name not in ordered:
+                ordered.append(name)
+
+        if not ordered:
+            raise ValueError("No research providers available")
+        return ordered
+
+    def _prepare_provider(
+        self,
+        provider_name: str,
+        model: Optional[str],
+        provider_params: Optional[dict],
+    ) -> ResearchProvider:
+        """Resolve one candidate into a provider instance ready to be called.
+
+        Args:
+            provider_name: Name of the provider to prepare.
+            model: Model override, if the caller gave one.
+            provider_params: Provider-specific parameters, if any.
+
+        Returns:
+            A provider instance configured for this run.
+
+        Raises:
+            ProviderNotConfiguredError: If the provider is known but not set up.
+            ValueError: If the name is not a provider at all.
+        """
+        base_provider = self.registry.get_provider(provider_name)
+        if not base_provider:
+            # Providers register only once their credential is present, so
+            # a known name that is absent means "not set up", not "no such
+            # thing". Saying "not found" sends the caller hunting a typo.
+            if provider_name in PROVIDER_CLASS_PATHS:
+                raise ProviderNotConfiguredError(
+                    provider_name, self._unregistered_reason(provider_name)
+                )
+            raise ValueError(f"Provider '{provider_name}' not found")
+        if not base_provider.is_available():
+            raise ProviderNotConfiguredError(
+                provider_name, base_provider.unavailable_reason()
+            )
+
+        # Create new instance with custom parameters if needed
+        if provider_params or model:
+            return self._create_provider_with_params(
+                provider_name, model, provider_params or {}
+            )
+        return base_provider
+
+    @staticmethod
+    def _warn_falling_back(
+        failed_provider: str,
+        next_provider: str,
+        exc: BaseException,
+        model: Optional[str],
+        provider_params: Optional[dict],
+    ) -> None:
+        """Say which provider is taking over, and what is being dropped to do it.
+
+        Args:
+            failed_provider: The provider that could not do the work.
+            next_provider: The provider about to be tried.
+            exc: The failure that ended the previous attempt.
+            model: Model override the caller asked for, if any.
+            provider_params: Provider-specific parameters the caller asked for.
+        """
+        logger.warning(
+            "Provider %s cannot do this run: %s. Falling back to %s",
+            failed_provider, exc, next_provider,
+        )
+        dropped = [
+            label
+            for label, value in (("--model", model), ("--param", provider_params))
+            if value
+        ]
+        if dropped:
+            logger.warning(
+                "%s runs on its own defaults: %s applied to %s, not to it",
+                next_provider, " and ".join(dropped), failed_provider,
+            )
+
+    @staticmethod
+    def _record_provenance(
+        result: ResearchResult,
+        requested: Optional[str],
+        failed: list[ProviderAttempt],
+        used: str,
+    ) -> None:
+        """Stamp a result with who was asked, who was tried, and who answered.
+
+        Called after the result has been cached, never before: these fields
+        describe *this* run, and replaying them out of a cache file would
+        credit a later run with a fallback that never happened.
+
+        Args:
+            result: The result to stamp.
+            requested: Provider the caller named, if any.
+            failed: Attempts that failed, in the order they were tried.
+            used: Provider that produced the result.
+        """
+        result.requested_provider = requested
+        result.provider_attempts = [
+            *failed,
+            ProviderAttempt(provider=used, succeeded=True),
+        ]
+
     def research(
         self,
         query: str,
@@ -335,7 +485,8 @@ class DeepResearchClient:
         template_info: Optional[dict] = None,
         model: Optional[str] = None,
         provider_params: Optional[dict] = None,
-        metadata: Optional[dict] = None
+        metadata: Optional[dict] = None,
+        fallback: Union[bool, Sequence[str]] = False,
     ) -> ResearchResult:
         """Perform research on the given query.
 
@@ -346,6 +497,10 @@ class DeepResearchClient:
             model: Model to use for the provider (overrides provider default)
             provider_params: Provider-specific parameters
             metadata: Publication-style metadata (title, abstract, keywords, author, contributors)
+            fallback: Opt in to trying another provider when this one cannot do
+                the work. False (the default) never switches providers. True
+                falls back to whatever else is available. A list names the
+                providers to try, in order.
 
         Returns:
             ResearchResult with markdown content and citations
@@ -356,7 +511,17 @@ class DeepResearchClient:
             ValueError: If no providers are available, or the name is not a
                 provider at all
         """
-        return asyncio.run(self.aresearch(query, provider, template_info, model, provider_params, metadata))
+        return asyncio.run(
+            self.aresearch(
+                query,
+                provider,
+                template_info,
+                model,
+                provider_params,
+                metadata,
+                fallback,
+            )
+        )
 
     async def aresearch(
         self,
@@ -365,105 +530,146 @@ class DeepResearchClient:
         template_info: Optional[dict] = None,
         model: Optional[str] = None,
         provider_params: Optional[dict] = None,
-        metadata: Optional[dict] = None
+        metadata: Optional[dict] = None,
+        fallback: Union[bool, Sequence[str]] = False,
     ) -> ResearchResult:
-        """Async version of research method."""
+        """Async version of research method.
+
+        Falling back is opt-in and never silent: whoever produced the report is
+        recorded on it, along with everyone who was tried first and why they
+        could not. Only failures that mean "this provider cannot do the work"
+        are followed -- a throttle or a 5xx says to wait, not to switch, so
+        those propagate as they always did.
+
+        Nothing is cached or returned until a provider actually succeeds, so a
+        run that exhausts every candidate raises rather than producing a
+        partial result.
+        """
         start_time = datetime.now()
         start_timestamp = time.time()
 
-        # Get provider
-        if provider:
-            base_provider = self.registry.get_provider(provider)
-            if not base_provider:
-                # Providers register only once their credential is present, so
-                # a known name that is absent means "not set up", not "no such
-                # thing". Saying "not found" sends the caller hunting a typo.
-                if provider in PROVIDER_CLASS_PATHS:
-                    raise ProviderNotConfiguredError(
-                        provider, self._unregistered_reason(provider)
-                    )
-                raise ValueError(f"Provider '{provider}' not found")
-            if not base_provider.is_available():
-                raise ProviderNotConfiguredError(provider, base_provider.unavailable_reason())
+        candidates = self._fallback_candidates(provider, fallback)
+        failed: list[ProviderAttempt] = []
 
-            # Create new instance with custom parameters if needed
-            if provider_params or model:
-                research_provider = self._create_provider_with_params(provider, model, provider_params or {})
-            else:
-                research_provider = base_provider
-        else:
-            base_provider = self.registry.get_first_available()
-            if not base_provider:
-                raise ValueError("No research providers available")
+        for position, candidate in enumerate(candidates):
+            # The last candidate has nowhere to fall back to, so its failure is
+            # the run's failure and propagates untouched -- same type, same
+            # traceback a caller would have seen with no fallback at all.
+            last = position == len(candidates) - 1
 
-            provider_name = base_provider.name
-            # Create new instance with custom parameters if needed
-            if provider_params or model:
-                research_provider = self._create_provider_with_params(provider_name, model, provider_params or {})
-            else:
-                research_provider = base_provider
+            # A model name and provider parameters were chosen for the provider
+            # the caller named; they mean nothing to a different one, and an
+            # unknown parameter is a hard schema error. So they apply to the
+            # first candidate only, and a fallback runs on its own defaults --
+            # said out loud below, because it is a change to what was asked.
+            first = position == 0
+            effective_model = model if first else None
+            effective_params = provider_params if first else None
 
-        # Check cache first
-        cache_provider_params = self._get_cache_provider_params(research_provider, provider_params)
-        cached_result = await self.cache.get(query, research_provider.name, model, cache_provider_params)
-        if cached_result:
-            # Update timing for cached results
-            end_time = datetime.now()
-            cached_result.start_time = start_time
-            cached_result.end_time = end_time
-            cached_result.duration_seconds = time.time() - start_timestamp
-            return cached_result
-
-        # Perform research
-        result = await research_provider.research(query)
-
-        # Add timing and metadata
-        end_time = datetime.now()
-        result.start_time = start_time
-        result.end_time = end_time
-        result.duration_seconds = time.time() - start_timestamp
-
-        # Add template information if provided
-        if template_info:
-            result.template_file = template_info.get('template_file')
-            result.template_variables = template_info.get('template_variables')
-
-        # Add publication-style metadata if provided
-        if metadata:
-            if 'title' in metadata:
-                result.title = metadata['title']
-            if 'abstract' in metadata:
-                result.abstract = metadata['abstract']
-            if 'keywords' in metadata:
-                result.keywords = metadata['keywords']
-            if 'author' in metadata or 'contributors' in metadata:
-                result.query_metadata = QueryMetadata(
-                    author=metadata.get('author'),
-                    contributors=metadata.get('contributors', [])
+            try:
+                research_provider = self._prepare_provider(
+                    candidate, effective_model, effective_params
                 )
+            except Exception as exc:
+                if last or not is_fallback_worthy(exc):
+                    raise
+                failed.append(ProviderAttempt.from_exception(candidate, exc))
+                self._warn_falling_back(
+                    candidate, candidates[position + 1], exc, model, provider_params
+                )
+                continue
 
-        # Add provider configuration. Prefer a model the provider already recorded
-        # on the result (e.g. the actual model id reported by the run) over the
-        # provider's configured/default model.
-        if result.model is None:
-            result.model = getattr(research_provider, 'model', None)
-        result.provider_config = {
-            'timeout': research_provider.config.timeout,
-            'max_retries': research_provider.config.max_retries,
-        }
+            # Check cache first
+            cache_provider_params = self._get_cache_provider_params(
+                research_provider, effective_params
+            )
+            cached_result = await self.cache.get(
+                query, research_provider.name, effective_model, cache_provider_params
+            )
+            if cached_result:
+                # Update timing for cached results
+                end_time = datetime.now()
+                cached_result.start_time = start_time
+                cached_result.end_time = end_time
+                cached_result.duration_seconds = time.time() - start_timestamp
+                self._record_provenance(
+                    cached_result, provider, failed, research_provider.name
+                )
+                return cached_result
 
-        # Add provider-specific parameters if they exist
-        params = getattr(research_provider, "params", None)
-        if isinstance(params, BaseProviderParams):
-            # Convert Pydantic model to dict, excluding None values and model field
-            params_dict = params.model_dump(exclude_none=True, exclude={'model'})
-            if params_dict:
-                result.provider_config['parameters'] = params_dict
+            # Perform research
+            try:
+                result = await research_provider.research(query)
+            except Exception as exc:
+                if last or not is_fallback_worthy(exc):
+                    raise
+                failed.append(ProviderAttempt.from_exception(candidate, exc))
+                self._warn_falling_back(
+                    candidate, candidates[position + 1], exc, model, provider_params
+                )
+                continue
 
-        # Cache the result
-        await self.cache.set(query, research_provider.name, result, model, cache_provider_params)
+            # Add timing and metadata
+            end_time = datetime.now()
+            result.start_time = start_time
+            result.end_time = end_time
+            result.duration_seconds = time.time() - start_timestamp
 
-        return result
+            # Add template information if provided
+            if template_info:
+                result.template_file = template_info.get('template_file')
+                result.template_variables = template_info.get('template_variables')
+
+            # Add publication-style metadata if provided
+            if metadata:
+                if 'title' in metadata:
+                    result.title = metadata['title']
+                if 'abstract' in metadata:
+                    result.abstract = metadata['abstract']
+                if 'keywords' in metadata:
+                    result.keywords = metadata['keywords']
+                if 'author' in metadata or 'contributors' in metadata:
+                    result.query_metadata = QueryMetadata(
+                        author=metadata.get('author'),
+                        contributors=metadata.get('contributors', [])
+                    )
+
+            # Add provider configuration. Prefer a model the provider already recorded
+            # on the result (e.g. the actual model id reported by the run) over the
+            # provider's configured/default model.
+            if result.model is None:
+                result.model = getattr(research_provider, 'model', None)
+            result.provider_config = {
+                'timeout': research_provider.config.timeout,
+                'max_retries': research_provider.config.max_retries,
+            }
+
+            # Add provider-specific parameters if they exist
+            params = getattr(research_provider, "params", None)
+            if isinstance(params, BaseProviderParams):
+                # Convert Pydantic model to dict, excluding None values and model field
+                params_dict = params.model_dump(exclude_none=True, exclude={'model'})
+                if params_dict:
+                    result.provider_config['parameters'] = params_dict
+
+            # Cache the result
+            await self.cache.set(
+                query, research_provider.name, result, effective_model, cache_provider_params
+            )
+
+            # After caching, so that which providers this run tried never
+            # becomes part of what a later run reads back.
+            self._record_provenance(result, provider, failed, research_provider.name)
+            if result.fell_back:
+                logger.warning(
+                    "Report produced by %s, not the provider first tried (%s)",
+                    result.provider, failed[0].provider,
+                )
+            return result
+
+        # Unreachable: _fallback_candidates never returns an empty list, and the
+        # last candidate re-raises rather than falling out of the loop.
+        raise ValueError("No research providers available")
 
     def get_available_providers(self) -> list[str]:
         """Get list of available provider names."""

--- a/src/deep_research_client/client.py
+++ b/src/deep_research_client/client.py
@@ -510,16 +510,27 @@ class DeepResearchClient:
         exception instead -- including the candidate whose failure is being
         raised, so the list is the whole run and not everything before it.
 
+        A failure we did not classify has nowhere to carry it -- a provider
+        that cannot recognise its own SDK error re-raises it bare, and a plain
+        exception has no field for this. That is the run where the fallback
+        machinery worked hardest, so the trail is logged rather than lost.
+
         Args:
             exc: The failure about to be re-raised.
             failed: Attempts that failed earlier, in order.
             candidate: The provider whose failure ends the run.
         """
-        if not failed or not isinstance(exc, ProviderError):
+        if not failed:
             return
-        exc.provider_attempts = (
-            *failed,
-            ProviderAttempt.from_exception(candidate, exc),
+        trail = (*failed, ProviderAttempt.from_exception(candidate, exc))
+        if isinstance(exc, ProviderError):
+            exc.provider_attempts = trail
+            return
+        logger.warning(
+            "Every provider failed, and %s cannot carry the trail. "
+            "Providers tried:\n  %s",
+            type(exc).__name__,
+            "\n  ".join(attempt.summary() for attempt in trail),
         )
 
     @staticmethod

--- a/src/deep_research_client/client.py
+++ b/src/deep_research_client/client.py
@@ -515,6 +515,11 @@ class DeepResearchClient:
         exception has no field for this. That is the run where the fallback
         machinery worked hardest, so the trail is logged rather than lost.
 
+        The log names the candidate that ended the run rather than claiming
+        every one failed: an unclassified failure is not fallback-worthy, so
+        it ends the run wherever it happens, and candidates behind it are
+        left untried.
+
         Args:
             exc: The failure about to be re-raised.
             failed: Attempts that failed earlier, in order.
@@ -527,8 +532,9 @@ class DeepResearchClient:
             exc.provider_attempts = trail
             return
         logger.warning(
-            "Every provider failed, and %s cannot carry the trail. "
+            "Provider %s failed with %s, which cannot carry the trail. "
             "Providers tried:\n  %s",
+            candidate,
             type(exc).__name__,
             "\n  ".join(attempt.summary() for attempt in trail),
         )

--- a/src/deep_research_client/client.py
+++ b/src/deep_research_client/client.py
@@ -553,7 +553,7 @@ class DeepResearchClient:
             provider_params: Provider-specific parameters
             metadata: Publication-style metadata (title, abstract, keywords, author, contributors)
             fallback: Opt in to trying another provider when this one cannot do
-                the work. False (the default) never switches providers. True
+                the work. False (the default) or None never switches. True
                 falls back to whatever else is available, in registration
                 order, excluding providers that do not do real research. A
                 list -- or a bare string, for one -- names them explicitly, in
@@ -607,9 +607,18 @@ class DeepResearchClient:
 
         candidates = self._fallback_candidates(provider, fallback)
         failed: list[ProviderAttempt] = []
+        # Kept alongside `failed` so the run that exhausts every candidate can
+        # chain rather than discard: each earlier `except` exits via `continue`,
+        # so by the time the last one raises it is no longer being handled and
+        # __context__ is None. Without this a caller sees the final failure and
+        # has no evidence the others were tried.
+        last_failure: Optional[BaseException] = None
 
         async def serve_cached(
-            candidate: str, cached_model: Optional[str], cache_params: Optional[dict]
+            candidate: str,
+            cached_model: Optional[str],
+            cache_params: Optional[dict],
+            unreachable: Optional[BaseException] = None,
         ) -> Optional[ResearchResult]:
             """Return this candidate's cached report, stamped for this run.
 
@@ -622,6 +631,10 @@ class DeepResearchClient:
                 candidate: Provider whose cache entry is wanted.
                 cached_model: Model to key the entry by, if any.
                 cache_params: Provider parameters to key the entry by.
+                unreachable: The failure that stopped this provider running, when
+                    the entry is being served in place of a live call. Announced
+                    before the result is stamped, so the reason reaches the log
+                    ahead of the outcome it caused.
 
             Returns:
                 The stamped result, or None when nothing is cached.
@@ -629,6 +642,17 @@ class DeepResearchClient:
             cached = await self.cache.get(query, candidate, cached_model, cache_params)
             if cached is None:
                 return None
+            if unreachable is not None:
+                # Say it even though the run succeeds: the next uncached query
+                # will not, and nothing else records why. No attempt is
+                # appended, because the cached report really was produced by
+                # this provider -- so this line is the only thing standing
+                # between a revoked credential and silence.
+                logger.warning(
+                    "Provider %s cannot do this run: %s. "
+                    "Serving the report it produced for this query earlier",
+                    candidate, unreachable,
+                )
             cached.start_time = start_time
             cached.end_time = datetime.now()
             cached.duration_seconds = time.time() - start_timestamp
@@ -660,6 +684,8 @@ class DeepResearchClient:
                 )
             except Exception as exc:
                 if last or not is_fallback_worthy(exc):
+                    if last_failure is not None:
+                        raise exc from last_failure
                     raise
                 # Reading a report off disk needs no credential, so a
                 # provider we can no longer reach can still serve one it
@@ -673,22 +699,12 @@ class DeepResearchClient:
                 # the run fails exactly as it did before any of this, which is
                 # what keeps the default, no-fallback path byte-identical.
                 served = await serve_cached(
-                    candidate, effective_model, cache_provider_params
+                    candidate, effective_model, cache_provider_params, exc
                 )
                 if served is not None:
-                    # Say it even though the run succeeds: the next uncached
-                    # query will not, and nothing else on this path records
-                    # why. No attempt is appended, because the cached report
-                    # really was produced by this provider -- so the log line
-                    # is the only thing standing between a revoked credential
-                    # and silence.
-                    logger.warning(
-                        "Provider %s cannot do this run: %s. "
-                        "Serving the report it produced for this query earlier",
-                        candidate, exc,
-                    )
                     return served
                 failed.append(ProviderAttempt.from_exception(candidate, exc))
+                last_failure = exc
                 self._warn_falling_back(
                     candidate, candidates[position + 1], exc, model,
                     provider_params, candidates[0],
@@ -707,8 +723,11 @@ class DeepResearchClient:
                 result = await research_provider.research(query)
             except Exception as exc:
                 if last or not is_fallback_worthy(exc):
+                    if last_failure is not None:
+                        raise exc from last_failure
                     raise
                 failed.append(ProviderAttempt.from_exception(candidate, exc))
+                last_failure = exc
                 self._warn_falling_back(
                     candidate, candidates[position + 1], exc, model,
                     provider_params, candidates[0],

--- a/src/deep_research_client/client.py
+++ b/src/deep_research_client/client.py
@@ -335,25 +335,6 @@ class DeepResearchClient:
 
         return effective_params or None
 
-    def knows_provider(self, name: str) -> bool:
-        """Report whether a name is a provider at all, configured or not.
-
-        The distinction this draws is the one that decides which error a caller
-        gets: a known provider with no credential is *not configured* and can
-        be fallen back from, while an unrecognised name is a typo and the
-        remedy is a list of the names that exist. Both the fallback list and
-        the CLI's pre-check ask it, so it is answered once here rather than
-        spelled out at each site -- it has already been got wrong once by
-        being spelled out twice.
-
-        Args:
-            name: Provider name to check.
-
-        Returns:
-            True when the name is one this client could resolve.
-        """
-        return name in PROVIDER_CLASS_PATHS or self.registry.get_provider(name) is not None
-
     def _fallback_candidates(
         self,
         provider: Optional[str],
@@ -449,7 +430,7 @@ class DeepResearchClient:
             # Providers register only once their credential is present, so
             # a known name that is absent means "not set up", not "no such
             # thing". Saying "not found" sends the caller hunting a typo.
-            if provider_name in PROVIDER_CLASS_PATHS:
+            if self.knows_provider(provider_name):
                 raise ProviderNotConfiguredError(
                     provider_name, self._unregistered_reason(provider_name)
                 )
@@ -728,6 +709,44 @@ class DeepResearchClient:
         # Unreachable: _fallback_candidates never returns an empty list, and the
         # last candidate re-raises rather than falling out of the loop.
         raise ValueError("No research providers available")
+
+    def knows_provider(self, name: str) -> bool:
+        """Report whether a name is a provider at all, configured or not.
+
+        The distinction this draws is the one that decides which error a caller
+        gets: a known provider with no credential is *not configured* and can
+        be fallen back from, while an unrecognised name is a typo and the
+        remedy is a list of the names that exist.
+
+        Every site that has to tell those apart asks this -- the fallback list,
+        the CLI's pre-check, and the resolver that picks between the two error
+        types. Spelling it out instead is how it came to be missing from one of
+        them.
+
+        Args:
+            name: Provider name to check.
+
+        Returns:
+            True when the name is one this client could resolve.
+
+        Configuration is a different question, and deliberately not this one:
+        ``falcon`` is a provider whether or not a key is set for it, while a
+        transposed letter is not.
+
+        >>> client = DeepResearchClient(
+        ...     cache_config=CacheConfig(enabled=False),
+        ...     provider_configs={"mock": ProviderConfig(name="mock")},
+        ... )
+        >>> client.knows_provider("falcon"), client.knows_provider("falcn")
+        (True, False)
+
+        A name registered by a caller counts too, even though no environment
+        variable would ever produce it:
+
+        >>> client.knows_provider("mock")
+        True
+        """
+        return name in PROVIDER_CLASS_PATHS or self.registry.get_provider(name) is not None
 
     def get_available_providers(self) -> list[str]:
         """Get list of available provider names."""

--- a/src/deep_research_client/client.py
+++ b/src/deep_research_client/client.py
@@ -350,15 +350,15 @@ class DeepResearchClient:
     def _fallback_candidates(
         self,
         provider: Optional[str],
-        fallback: Union[bool, str, Sequence[str]],
+        fallback: Optional[Union[bool, str, Sequence[str]]],
     ) -> list[str]:
         """Work out which providers to try, in order.
 
         Args:
             provider: Provider the caller named, if any.
-            fallback: False for no fallback, True to fall back to whatever else
-                is available, or an ordered list of provider names. A single
-                name may be given as a bare string.
+            fallback: False or None for no fallback, True to fall back to
+                whatever else is available, or an ordered list of provider
+                names. A single name may be given as a bare string.
 
         Returns:
             Provider names to try, most-preferred first, without duplicates.
@@ -373,7 +373,10 @@ class DeepResearchClient:
             # become six one-letter providers. The singular form is the obvious
             # thing to reach for next to a list, so honour it.
             extra = [fallback]
-        elif isinstance(fallback, bool):
+        elif fallback is None or isinstance(fallback, bool):
+            # None arrives the same way the bare string does -- a wrapper
+            # passing config.get("fallback") for an absent key -- and means
+            # the same thing as False. Falling through would reach list(None).
             extra = (
                 [
                     candidate.name
@@ -538,7 +541,7 @@ class DeepResearchClient:
         model: Optional[str] = None,
         provider_params: Optional[dict] = None,
         metadata: Optional[dict] = None,
-        fallback: Union[bool, str, Sequence[str]] = False,
+        fallback: Optional[Union[bool, str, Sequence[str]]] = False,
     ) -> ResearchResult:
         """Perform research on the given query.
 
@@ -585,7 +588,7 @@ class DeepResearchClient:
         model: Optional[str] = None,
         provider_params: Optional[dict] = None,
         metadata: Optional[dict] = None,
-        fallback: Union[bool, str, Sequence[str]] = False,
+        fallback: Optional[Union[bool, str, Sequence[str]]] = False,
     ) -> ResearchResult:
         """Async version of research method.
 
@@ -673,6 +676,17 @@ class DeepResearchClient:
                     candidate, effective_model, cache_provider_params
                 )
                 if served is not None:
+                    # Say it even though the run succeeds: the next uncached
+                    # query will not, and nothing else on this path records
+                    # why. No attempt is appended, because the cached report
+                    # really was produced by this provider -- so the log line
+                    # is the only thing standing between a revoked credential
+                    # and silence.
+                    logger.warning(
+                        "Provider %s cannot do this run: %s. "
+                        "Serving the report it produced for this query earlier",
+                        candidate, exc,
+                    )
                     return served
                 failed.append(ProviderAttempt.from_exception(candidate, exc))
                 self._warn_falling_back(

--- a/src/deep_research_client/client.py
+++ b/src/deep_research_client/client.py
@@ -335,6 +335,25 @@ class DeepResearchClient:
 
         return effective_params or None
 
+    def knows_provider(self, name: str) -> bool:
+        """Report whether a name is a provider at all, configured or not.
+
+        The distinction this draws is the one that decides which error a caller
+        gets: a known provider with no credential is *not configured* and can
+        be fallen back from, while an unrecognised name is a typo and the
+        remedy is a list of the names that exist. Both the fallback list and
+        the CLI's pre-check ask it, so it is answered once here rather than
+        spelled out at each site -- it has already been got wrong once by
+        being spelled out twice.
+
+        Args:
+            name: Provider name to check.
+
+        Returns:
+            True when the name is one this client could resolve.
+        """
+        return name in PROVIDER_CLASS_PATHS or self.registry.get_provider(name) is not None
+
     def _fallback_candidates(
         self,
         provider: Optional[str],
@@ -383,11 +402,7 @@ class DeepResearchClient:
         # mid-run would abort after the first provider had already been paid
         # for, never reach the good candidate behind it, and replace the
         # failure that started the fallback with a bare "not found".
-        unknown = [
-            name
-            for name in extra
-            if name not in PROVIDER_CLASS_PATHS and self.registry.get_provider(name) is None
-        ]
+        unknown = [name for name in extra if not self.knows_provider(name)]
         if unknown:
             raise ValueError(
                 f"Provider '{unknown[0]}' not found"

--- a/src/deep_research_client/client.py
+++ b/src/deep_research_client/client.py
@@ -313,8 +313,8 @@ class DeepResearchClient:
         # Get provider class and create instance
         return self._create_provider(provider_name, config, params)
 
+    @staticmethod
     def _get_cache_provider_params(
-        self,
         provider_name: str,
         provider_params: Optional[dict] = None,
     ) -> Optional[dict]:
@@ -496,6 +496,34 @@ class DeepResearchClient:
                 next_provider, " and ".join(dropped), overridden_provider,
             )
 
+    def _finish_cached(
+        self,
+        cached_result: ResearchResult,
+        start_time: datetime,
+        start_timestamp: float,
+        requested: Optional[str],
+        failed: list[ProviderAttempt],
+        candidate: str,
+    ) -> ResearchResult:
+        """Stamp a cached result with this run's timing and provenance.
+
+        Args:
+            cached_result: The result read from the cache.
+            start_time: When this run started.
+            start_timestamp: Monotonic start, for the duration.
+            requested: Provider the caller named, if any.
+            failed: Attempts that failed before this one, in order.
+            candidate: Provider whose cache entry this is.
+
+        Returns:
+            The result, ready to return to the caller.
+        """
+        cached_result.start_time = start_time
+        cached_result.end_time = datetime.now()
+        cached_result.duration_seconds = time.time() - start_timestamp
+        self._record_provenance(cached_result, requested, failed, candidate)
+        return cached_result
+
     @staticmethod
     def _record_provenance(
         result: ResearchResult,
@@ -620,26 +648,9 @@ class DeepResearchClient:
             effective_model = model if first else None
             effective_params = provider_params if first else None
 
-            # The cache is consulted before the provider is prepared, because
-            # a report already on disk needs no credential. A provider whose
-            # key was revoked can still answer from one -- and paying the next
-            # provider for a report we already have would be a poor trade,
-            # made likelier by the CLI now standing its availability check
-            # down whenever a fallback was asked for.
             cache_provider_params = self._get_cache_provider_params(
                 candidate, effective_params
             )
-            cached_result = await self.cache.get(
-                query, candidate, effective_model, cache_provider_params
-            )
-            if cached_result:
-                # Update timing for cached results
-                end_time = datetime.now()
-                cached_result.start_time = start_time
-                cached_result.end_time = end_time
-                cached_result.duration_seconds = time.time() - start_timestamp
-                self._record_provenance(cached_result, provider, failed, candidate)
-                return cached_result
 
             try:
                 research_provider = self._prepare_provider(
@@ -648,12 +659,36 @@ class DeepResearchClient:
             except Exception as exc:
                 if last or not is_fallback_worthy(exc):
                     raise
+                # Only here, and only before billing someone else: reading a
+                # report off disk needs no credential, so a provider we can no
+                # longer reach can still serve one it produced earlier. On the
+                # last candidate there is nobody to bill, so it fails exactly
+                # as it did before any of this -- which is what keeps the
+                # default, no-fallback path byte-identical.
+                cached_result = await self.cache.get(
+                    query, candidate, effective_model, cache_provider_params
+                )
+                if cached_result:
+                    return self._finish_cached(
+                        cached_result, start_time, start_timestamp,
+                        provider, failed, candidate,
+                    )
                 failed.append(ProviderAttempt.from_exception(candidate, exc))
                 self._warn_falling_back(
                     candidate, candidates[position + 1], exc, model,
                     provider_params, candidates[0],
                 )
                 continue
+
+            # Check cache first
+            cached_result = await self.cache.get(
+                query, candidate, effective_model, cache_provider_params
+            )
+            if cached_result:
+                return self._finish_cached(
+                    cached_result, start_time, start_timestamp,
+                    provider, failed, candidate,
+                )
 
             # Perform research
             try:

--- a/src/deep_research_client/client.py
+++ b/src/deep_research_client/client.py
@@ -496,34 +496,6 @@ class DeepResearchClient:
                 next_provider, " and ".join(dropped), overridden_provider,
             )
 
-    def _finish_cached(
-        self,
-        cached_result: ResearchResult,
-        start_time: datetime,
-        start_timestamp: float,
-        requested: Optional[str],
-        failed: list[ProviderAttempt],
-        candidate: str,
-    ) -> ResearchResult:
-        """Stamp a cached result with this run's timing and provenance.
-
-        Args:
-            cached_result: The result read from the cache.
-            start_time: When this run started.
-            start_timestamp: Monotonic start, for the duration.
-            requested: Provider the caller named, if any.
-            failed: Attempts that failed before this one, in order.
-            candidate: Provider whose cache entry this is.
-
-        Returns:
-            The result, ready to return to the caller.
-        """
-        cached_result.start_time = start_time
-        cached_result.end_time = datetime.now()
-        cached_result.duration_seconds = time.time() - start_timestamp
-        self._record_provenance(cached_result, requested, failed, candidate)
-        return cached_result
-
     @staticmethod
     def _record_provenance(
         result: ResearchResult,
@@ -633,6 +605,33 @@ class DeepResearchClient:
         candidates = self._fallback_candidates(provider, fallback)
         failed: list[ProviderAttempt] = []
 
+        async def serve_cached(
+            candidate: str, cached_model: Optional[str], cache_params: Optional[dict]
+        ) -> Optional[ResearchResult]:
+            """Return this candidate's cached report, stamped for this run.
+
+            Closes over what does not vary across candidates, so the two places
+            that may serve a cached result cannot drift on how they stamp one --
+            the same reason the fallback warning lives inside _record_provenance
+            rather than at each return.
+
+            Args:
+                candidate: Provider whose cache entry is wanted.
+                cached_model: Model to key the entry by, if any.
+                cache_params: Provider parameters to key the entry by.
+
+            Returns:
+                The stamped result, or None when nothing is cached.
+            """
+            cached = await self.cache.get(query, candidate, cached_model, cache_params)
+            if cached is None:
+                return None
+            cached.start_time = start_time
+            cached.end_time = datetime.now()
+            cached.duration_seconds = time.time() - start_timestamp
+            self._record_provenance(cached, provider, failed, candidate)
+            return cached
+
         for position, candidate in enumerate(candidates):
             # The last candidate has nowhere to fall back to, so its failure is
             # the run's failure and propagates untouched -- same type, same
@@ -659,20 +658,22 @@ class DeepResearchClient:
             except Exception as exc:
                 if last or not is_fallback_worthy(exc):
                     raise
-                # Only here, and only before billing someone else: reading a
-                # report off disk needs no credential, so a provider we can no
-                # longer reach can still serve one it produced earlier. On the
-                # last candidate there is nobody to bill, so it fails exactly
-                # as it did before any of this -- which is what keeps the
-                # default, no-fallback path byte-identical.
-                cached_result = await self.cache.get(
-                    query, candidate, effective_model, cache_provider_params
+                # Reading a report off disk needs no credential, so a
+                # provider we can no longer reach can still serve one it
+                # produced earlier, rather than the next candidate being
+                # called for a report we already hold.
+                #
+                # The predicate is "another candidate remains", not "someone
+                # would otherwise be billed" -- the two come apart, since a
+                # remaining candidate may be a permanently unavailable stub.
+                # It is deliberately the narrower one: on the last candidate
+                # the run fails exactly as it did before any of this, which is
+                # what keeps the default, no-fallback path byte-identical.
+                served = await serve_cached(
+                    candidate, effective_model, cache_provider_params
                 )
-                if cached_result:
-                    return self._finish_cached(
-                        cached_result, start_time, start_timestamp,
-                        provider, failed, candidate,
-                    )
+                if served is not None:
+                    return served
                 failed.append(ProviderAttempt.from_exception(candidate, exc))
                 self._warn_falling_back(
                     candidate, candidates[position + 1], exc, model,
@@ -680,15 +681,12 @@ class DeepResearchClient:
                 )
                 continue
 
-            # Check cache first
-            cached_result = await self.cache.get(
-                query, candidate, effective_model, cache_provider_params
+            # The ordinary read, for a provider we were able to prepare.
+            served = await serve_cached(
+                candidate, effective_model, cache_provider_params
             )
-            if cached_result:
-                return self._finish_cached(
-                    cached_result, start_time, start_timestamp,
-                    provider, failed, candidate,
-                )
+            if served is not None:
+                return served
 
             # Perform research
             try:

--- a/src/deep_research_client/client.py
+++ b/src/deep_research_client/client.py
@@ -315,22 +315,34 @@ class DeepResearchClient:
 
     def _get_cache_provider_params(
         self,
-        research_provider: 'ResearchProvider',
+        provider_name: str,
         provider_params: Optional[dict] = None,
     ) -> Optional[dict]:
-        """Build effective cache parameters, including provider-specific cache busting."""
+        """Build effective cache parameters, including provider-specific cache busting.
+
+        Takes a name rather than a provider, because a cache key needs nothing
+        an instance has: that is what lets a cached report be served for a
+        provider this run cannot construct.
+
+        Args:
+            provider_name: Name of the provider whose cache entry is wanted.
+            provider_params: Provider-specific parameters for this run.
+
+        Returns:
+            Parameters to key the cache entry by, or None when there are none.
+        """
         effective_params = dict(provider_params or {})
 
         # Asta response parsing and paper metadata changed after initial release;
         # keep stale cache entries from shadowing current live results.
-        if research_provider.name == "asta":
+        if provider_name == "asta":
             effective_params["_cache_version"] = "snippet-v5"
-        elif research_provider.name in {"falcon", "openscientist"}:
+        elif provider_name in {"falcon", "openscientist"}:
             effective_params["_cache_version"] = "artifacts-v1"
         # The Claude Code prompt scaffolding (inline-report directive) and run
         # provenance capture changed how results are produced; bump to keep
         # stale cache entries from shadowing current live results.
-        elif research_provider.name == "claude_code":
+        elif provider_name == "claude_code":
             effective_params["_cache_version"] = "inline-report-v1"
 
         return effective_params or None
@@ -608,6 +620,27 @@ class DeepResearchClient:
             effective_model = model if first else None
             effective_params = provider_params if first else None
 
+            # The cache is consulted before the provider is prepared, because
+            # a report already on disk needs no credential. A provider whose
+            # key was revoked can still answer from one -- and paying the next
+            # provider for a report we already have would be a poor trade,
+            # made likelier by the CLI now standing its availability check
+            # down whenever a fallback was asked for.
+            cache_provider_params = self._get_cache_provider_params(
+                candidate, effective_params
+            )
+            cached_result = await self.cache.get(
+                query, candidate, effective_model, cache_provider_params
+            )
+            if cached_result:
+                # Update timing for cached results
+                end_time = datetime.now()
+                cached_result.start_time = start_time
+                cached_result.end_time = end_time
+                cached_result.duration_seconds = time.time() - start_timestamp
+                self._record_provenance(cached_result, provider, failed, candidate)
+                return cached_result
+
             try:
                 research_provider = self._prepare_provider(
                     candidate, effective_model, effective_params
@@ -621,24 +654,6 @@ class DeepResearchClient:
                     provider_params, candidates[0],
                 )
                 continue
-
-            # Check cache first
-            cache_provider_params = self._get_cache_provider_params(
-                research_provider, effective_params
-            )
-            cached_result = await self.cache.get(
-                query, research_provider.name, effective_model, cache_provider_params
-            )
-            if cached_result:
-                # Update timing for cached results
-                end_time = datetime.now()
-                cached_result.start_time = start_time
-                cached_result.end_time = end_time
-                cached_result.duration_seconds = time.time() - start_timestamp
-                self._record_provenance(
-                    cached_result, provider, failed, research_provider.name
-                )
-                return cached_result
 
             # Perform research
             try:
@@ -698,12 +713,12 @@ class DeepResearchClient:
 
             # Cache the result
             await self.cache.set(
-                query, research_provider.name, result, effective_model, cache_provider_params
+                query, candidate, result, effective_model, cache_provider_params
             )
 
             # After caching, so that which providers this run tried never
             # becomes part of what a later run reads back.
-            self._record_provenance(result, provider, failed, research_provider.name)
+            self._record_provenance(result, provider, failed, candidate)
             return result
 
         # Unreachable: _fallback_candidates never returns an empty list, and the
@@ -723,12 +738,6 @@ class DeepResearchClient:
         types. Spelling it out instead is how it came to be missing from one of
         them.
 
-        Args:
-            name: Provider name to check.
-
-        Returns:
-            True when the name is one this client could resolve.
-
         Configuration is a different question, and deliberately not this one:
         ``falcon`` is a provider whether or not a key is set for it, while a
         transposed letter is not.
@@ -740,11 +749,20 @@ class DeepResearchClient:
         >>> client.knows_provider("falcon"), client.knows_provider("falcn")
         (True, False)
 
-        A name registered by a caller counts too, even though no environment
-        variable would ever produce it:
+        The registry is consulted as well as the known names, so a provider put
+        there directly under a name no environment variable produces still
+        counts:
 
-        >>> client.knows_provider("mock")
+        >>> from deep_research_client.providers.mock import MockProvider
+        >>> client.registry.register(MockProvider(ProviderConfig(name="spare")))
+        >>> client.knows_provider("spare")
         True
+
+        Args:
+            name: Provider name to check.
+
+        Returns:
+            True when the name is one this client could resolve.
         """
         return name in PROVIDER_CLASS_PATHS or self.registry.get_provider(name) is not None
 

--- a/src/deep_research_client/exceptions.py
+++ b/src/deep_research_client/exceptions.py
@@ -22,7 +22,10 @@ See https://github.com/monarch-initiative/deep-research-client/issues/65
 """
 
 import re
-from typing import ClassVar, Optional
+from typing import TYPE_CHECKING, ClassVar, Optional
+
+if TYPE_CHECKING:  # pragma: no cover - import only for type checking
+    from .models import ProviderAttempt
 
 #: Cap on how much provider-supplied text is allowed into an exception message.
 #: A 5xx HTML page or a Node stack trace is a hint, not something to reprint.
@@ -102,6 +105,16 @@ class ProviderError(ValueError):
     #: What the failure means and what would fix it. Usually a class-level
     #: constant, but an instance may sharpen it with provider-supplied detail.
     remedy: str = "check the provider configuration"
+
+    #: Every provider tried, when this failure is the one that ended a run
+    #: with a fallback. Empty on an ordinary single-provider failure.
+    #:
+    #: Deliberately not ``__cause__``: providers set that themselves, to the
+    #: upstream SDK error (``raise classified from e``), and taking the slot
+    #: would displace theirs to ``__context__`` where ``__suppress_context__``
+    #: hides it from the printed traceback. A run's trail and a failure's
+    #: cause are different facts, so they get different places.
+    provider_attempts: "tuple[ProviderAttempt, ...]" = ()
 
     def __init__(self, provider: str, detail: str, status_code: Optional[int] = None):
         """Build a provider error carrying its own remediation advice."""

--- a/src/deep_research_client/exceptions.py
+++ b/src/deep_research_client/exceptions.py
@@ -55,6 +55,8 @@ __all__ = [
     "ProviderRateLimitError",
     "ProviderTransientError",
     "truncate_detail",
+    "FALLBACK_WORTHY_ERRORS",
+    "is_fallback_worthy",
     "classify_status",
     "classify_exception",
     "extract_status_code",
@@ -397,3 +399,55 @@ def classify_exception(provider: str, exc: BaseException) -> Optional[ProviderEr
     if status_code is None:
         return None
     return classify_status(provider, status_code, str(exc))
+
+
+#: Failures that mean "this provider cannot do the work" -- so a *different*
+#: provider might succeed at the same request.
+#:
+#: This is deliberately a separate axis from :attr:`ProviderError.retryable`,
+#: not its inverse. ``retryable`` answers "would calling this provider again
+#: help?"; this answers "would calling someone else help?". Today's types make
+#: the two look complementary, but they are not the same question, and a future
+#: error meaning "the request itself is malformed" would answer no to both.
+FALLBACK_WORTHY_ERRORS: tuple[type[ProviderError], ...] = (
+    ProviderAuthError,
+    ProviderBillingError,
+    ProviderQuotaError,
+    # Covers ProviderNotInstalledError, which subclasses it.
+    ProviderNotConfiguredError,
+)
+
+
+def is_fallback_worthy(exc: BaseException) -> bool:
+    """Report whether another provider could succeed where this one failed.
+
+    Unrecognised failures answer False. A fallback is a silent change of who
+    produced the report, so it is taken only where the type is evidence that
+    this provider specifically cannot do the work -- never on a bare
+    ``ValueError`` whose cause nobody has established.
+
+    Args:
+        exc: The exception a provider raised.
+
+    Returns:
+        True when trying a different provider is justified.
+
+    >>> is_fallback_worthy(ProviderBillingError("falcon", "no credits", 402))
+    True
+    >>> is_fallback_worthy(ProviderNotInstalledError("cyberian", "no agentapi"))
+    True
+
+    A throttle or a 5xx is the same provider saying "not right now", so the
+    remedy is to wait, not to switch:
+
+    >>> is_fallback_worthy(ProviderRateLimitError("openai", "slow down", 429))
+    False
+    >>> is_fallback_worthy(ProviderTransientError("asta", "bad gateway", 502))
+    False
+
+    And an unclassified failure is not evidence of anything:
+
+    >>> is_fallback_worthy(ValueError("malformed response"))
+    False
+    """
+    return isinstance(exc, FALLBACK_WORTHY_ERRORS)

--- a/src/deep_research_client/exceptions.py
+++ b/src/deep_research_client/exceptions.py
@@ -114,6 +114,11 @@ class ProviderError(ValueError):
     #: would displace theirs to ``__context__`` where ``__suppress_context__``
     #: hides it from the printed traceback. A run's trail and a failure's
     #: cause are different facts, so they get different places.
+    #:
+    #: A tuple rather than a list, and deliberately so despite
+    #: ``ResearchResult.provider_attempts`` being a list: a mutable class-level
+    #: default would be shared by every instance. The immutable one is what
+    #: lets every error carry the attribute without an ``__init__`` change.
     provider_attempts: "tuple[ProviderAttempt, ...]" = ()
 
     def __init__(self, provider: str, detail: str, status_code: Optional[int] = None):

--- a/src/deep_research_client/formatter.py
+++ b/src/deep_research_client/formatter.py
@@ -56,6 +56,10 @@ class ResultFormatter:
         if result.run_metadata:
             metadata["run_metadata"] = result.run_metadata
 
+        # Record a fallback, and only a fallback: `provider` on its own would
+        # make a report produced by a stand-in read as a deliberate choice.
+        metadata.update(result.fallback_frontmatter())
+
         # Add citation count
         if result.citations:
             metadata["citation_count"] = len(result.citations)

--- a/src/deep_research_client/models.py
+++ b/src/deep_research_client/models.py
@@ -287,7 +287,10 @@ class ResearchResult(BaseModel):
         default_factory=list,
         description=(
             "Providers tried for this run, in order, and why each failed. "
-            "Describes this run only, so it is never read back from cache."
+            "`succeeded` means 'produced this report', which a provider that "
+            "answered from cache did even if this run could not reach it -- "
+            "`cached` is what tells the two apart. Describes this run only, "
+            "so it is never read back from cache."
         ),
     )
 

--- a/src/deep_research_client/models.py
+++ b/src/deep_research_client/models.py
@@ -98,6 +98,17 @@ class ProviderAttempt(BaseModel):
             "when the failure was not one we classify"
         ),
     )
+    status_code: Optional[int] = Field(
+        default=None, description="HTTP status, when the failure came from an HTTP call"
+    )
+    remedy: Optional[str] = Field(
+        default=None,
+        description=(
+            "What the failure means and what would fix it, in our words rather "
+            "than the provider's. Safe to write into a file that gets committed, "
+            "which `reason` is not: see fallback_frontmatter."
+        ),
+    )
 
     @classmethod
     def from_exception(cls, provider: str, exc: BaseException) -> "ProviderAttempt":
@@ -117,6 +128,8 @@ class ProviderAttempt(BaseModel):
         ('ProviderBillingError', False)
         >>> attempt.reason
         '402 no credits -- the account is out of credits'
+        >>> attempt.status_code, attempt.remedy
+        (402, 'the account is out of credits')
 
         An unclassified failure records what it can and leaves ``retryable``
         unset rather than guessing:
@@ -132,6 +145,8 @@ class ProviderAttempt(BaseModel):
                 error_type=type(exc).__name__,
                 reason=exc.diagnosis,
                 retryable=exc.retryable,
+                status_code=exc.status_code,
+                remedy=exc.remedy,
             )
         return cls(
             provider=provider,
@@ -139,6 +154,45 @@ class ProviderAttempt(BaseModel):
             error_type=type(exc).__name__,
             reason=truncate_detail(str(exc), MAX_DETAIL_CHARS),
         )
+
+    def frontmatter_entry(self) -> Dict[str, Any]:
+        """Render this attempt for a report that will be committed somewhere.
+
+        Deliberately drops ``reason``. That field embeds the provider's own
+        error text verbatim -- for an HTTP failure, the response body -- and a
+        401 body is the one most likely to quote the credential that was just
+        rejected. Some providers redact; we control neither their bodies nor,
+        once a report is committed, who reads the file afterwards.
+
+        Nothing is lost that justifies the switch: ``error_type``,
+        ``status_code`` and ``remedy`` say what happened and what would fix it,
+        and none of them is provider-supplied prose. The full text stays in the
+        logs and on the object, where it was before any of this was written to
+        disk.
+
+        Returns:
+            Keys safe to persist, with empty ones omitted.
+
+        >>> from .exceptions import ProviderAuthError
+        >>> leaky = ProviderAuthError("falcon", "Invalid API key: sk-live-abc123", 401)
+        >>> entry = ProviderAttempt.from_exception("falcon", leaky).frontmatter_entry()
+        >>> "sk-live-abc123" in str(entry)
+        False
+        >>> entry["remedy"]
+        'the API key is missing, invalid, or lacks access to this endpoint'
+        >>> ProviderAttempt(provider="openai", succeeded=True).frontmatter_entry()
+        {'provider': 'openai', 'succeeded': True}
+        """
+        entry: Dict[str, Any] = {"provider": self.provider, "succeeded": self.succeeded}
+        for key, value in (
+            ("error_type", self.error_type),
+            ("status_code", self.status_code),
+            ("remedy", self.remedy),
+            ("retryable", self.retryable),
+        ):
+            if value is not None:
+                entry[key] = value
+        return entry
 
     def summary(self) -> str:
         """Render this attempt as a single human-readable line.
@@ -238,6 +292,10 @@ class ResearchResult(BaseModel):
         formatter, and a fallback that only some reports admit to would be
         worse than one none of them mention.
 
+        Each attempt is rendered by :meth:`ProviderAttempt.frontmatter_entry`,
+        which withholds the provider's raw error text -- see there for why a
+        report is not the place for it.
+
         Returns:
             Frontmatter keys describing the fallback, or an empty dict when no
             fallback happened -- the presence of these keys is the finding.
@@ -255,7 +313,7 @@ class ResearchResult(BaseModel):
         >>> result.fallback_frontmatter()["requested_provider"]
         'falcon'
         >>> result.fallback_frontmatter()["provider_attempts"]
-        [{'provider': 'falcon', 'succeeded': False, 'reason': '402'}, {'provider': 'openai', 'succeeded': True}]
+        [{'provider': 'falcon', 'succeeded': False}, {'provider': 'openai', 'succeeded': True}]
         """
         if not self.fell_back:
             return {}
@@ -263,7 +321,7 @@ class ResearchResult(BaseModel):
         if self.requested_provider:
             metadata["requested_provider"] = self.requested_provider
         metadata["provider_attempts"] = [
-            attempt.model_dump(exclude_none=True) for attempt in self.provider_attempts
+            attempt.frontmatter_entry() for attempt in self.provider_attempts
         ]
         return metadata
 

--- a/src/deep_research_client/models.py
+++ b/src/deep_research_client/models.py
@@ -104,9 +104,12 @@ class ProviderAttempt(BaseModel):
     remedy: Optional[str] = Field(
         default=None,
         description=(
-            "What the failure means and what would fix it, in our words rather "
-            "than the provider's. Safe to write into a file that gets committed, "
-            "which `reason` is not: see fallback_frontmatter."
+            "What the failure means and what would fix it. Read from the error "
+            "*class*, never the instance, so it is ours in every case rather "
+            "than in most: ProviderQuotaError sharpens its own remedy with a "
+            "provider-supplied reset time, and an invariant with one silent "
+            "exception is not one a reader can rely on. The sharpened wording "
+            "is still on `reason`."
         ),
     )
 
@@ -146,7 +149,8 @@ class ProviderAttempt(BaseModel):
                 reason=exc.diagnosis,
                 retryable=exc.retryable,
                 status_code=exc.status_code,
-                remedy=exc.remedy,
+                # The class attribute, not exc.remedy: see the field above.
+                remedy=type(exc).remedy,
             )
         return cls(
             provider=provider,
@@ -170,6 +174,14 @@ class ProviderAttempt(BaseModel):
         logs and on the object, where it was before any of this was written to
         disk.
 
+        The rule this keeps is that every key here is one *we* produce, so it
+        can be checked by reading this list rather than by tracing each value
+        back to its origin. That is why a quota error's reset time -- parsed
+        out of provider text, and bounded only by a character cap that a
+        comma-separated account id fits inside -- does not appear, despite
+        being useful: it is worth little in a report read months later, and
+        keeping it would make the rule "ours, except one field".
+
         Returns:
             Keys safe to persist, with empty ones omitted.
 
@@ -182,6 +194,17 @@ class ProviderAttempt(BaseModel):
         'the API key is missing, invalid, or lacks access to this endpoint'
         >>> ProviderAttempt(provider="openai", succeeded=True).frontmatter_entry()
         {'provider': 'openai', 'succeeded': True}
+
+        A quota error keeps the reset time on ``reason`` and out of the report:
+
+        >>> from .exceptions import ProviderQuotaError
+        >>> spent = ProviderQuotaError(
+        ...     "claude_code", "usage limit reached", resets_at="10am, acct_9f3b21")
+        >>> attempt = ProviderAttempt.from_exception("claude_code", spent)
+        >>> attempt.frontmatter_entry()["remedy"]
+        "the plan's usage limit is spent"
+        >>> "acct_9f3b21" in attempt.reason
+        True
         """
         entry: Dict[str, Any] = {"provider": self.provider, "succeeded": self.succeeded}
         for key, value in (

--- a/src/deep_research_client/models.py
+++ b/src/deep_research_client/models.py
@@ -6,7 +6,7 @@ import re
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
-from .exceptions import MAX_DETAIL_CHARS, truncate_detail
+from .exceptions import MAX_DETAIL_CHARS, ProviderError, truncate_detail
 
 
 MAX_ARTIFACT_BYTES = 50 * 1024 * 1024
@@ -71,6 +71,91 @@ class ResearchArtifact(BaseModel):
         return (self.media_type or "").startswith("image/")
 
 
+class ProviderAttempt(BaseModel):
+    """One provider asked to do a research run, and how it answered.
+
+    A fallback changes who produced a report, which is exactly the kind of
+    thing a curator must be able to see afterwards rather than infer. One of
+    these is recorded per provider tried, in the order they were tried, so the
+    trail reads as a sequence rather than a single verdict.
+
+    >>> ProviderAttempt(provider="openai", succeeded=True).summary()
+    'openai: produced the report'
+    """
+
+    provider: str = Field(..., description="Name of the provider that was tried")
+    succeeded: bool = Field(..., description="Whether this provider produced the report")
+    error_type: Optional[str] = Field(
+        default=None, description="Class name of the failure, when this provider failed"
+    )
+    reason: Optional[str] = Field(
+        default=None, description="What the provider said, and what it means"
+    )
+    retryable: Optional[bool] = Field(
+        default=None,
+        description=(
+            "Whether calling this same provider again could have helped; None "
+            "when the failure was not one we classify"
+        ),
+    )
+
+    @classmethod
+    def from_exception(cls, provider: str, exc: BaseException) -> "ProviderAttempt":
+        """Record a failed attempt from the exception that ended it.
+
+        Args:
+            provider: Name of the provider that failed.
+            exc: The exception it raised.
+
+        Returns:
+            A failed attempt carrying whatever the failure could tell us.
+
+        >>> from .exceptions import ProviderBillingError
+        >>> attempt = ProviderAttempt.from_exception(
+        ...     "falcon", ProviderBillingError("falcon", "no credits", 402))
+        >>> attempt.error_type, attempt.retryable
+        ('ProviderBillingError', False)
+        >>> attempt.reason
+        '402 no credits -- the account is out of credits'
+
+        An unclassified failure records what it can and leaves ``retryable``
+        unset rather than guessing:
+
+        >>> plain = ProviderAttempt.from_exception("mock", RuntimeError("boom"))
+        >>> plain.error_type, plain.reason, plain.retryable
+        ('RuntimeError', 'boom', None)
+        """
+        if isinstance(exc, ProviderError):
+            return cls(
+                provider=provider,
+                succeeded=False,
+                error_type=type(exc).__name__,
+                reason=exc.diagnosis,
+                retryable=exc.retryable,
+            )
+        return cls(
+            provider=provider,
+            succeeded=False,
+            error_type=type(exc).__name__,
+            reason=truncate_detail(str(exc), MAX_DETAIL_CHARS),
+        )
+
+    def summary(self) -> str:
+        """Render this attempt as a single human-readable line.
+
+        Returns:
+            One line naming the provider and what happened.
+
+        >>> from .exceptions import ProviderQuotaError
+        >>> print(ProviderAttempt.from_exception(
+        ...     "claude_code", ProviderQuotaError("claude_code", "limit reached")).summary())
+        claude_code: limit reached -- the plan's usage limit is spent
+        """
+        if self.succeeded:
+            return f"{self.provider}: produced the report"
+        return f"{self.provider}: {self.reason or self.error_type or 'failed'}"
+
+
 class ResearchResult(BaseModel):
     """Result from a deep research query."""
 
@@ -108,6 +193,79 @@ class ResearchResult(BaseModel):
             "configuration in provider_config."
         ),
     )
+
+    # Which provider actually did the work. ``provider`` above already names
+    # the one that produced this report; these say what was *asked for* and
+    # what was tried on the way, so a report produced by a fallback can never
+    # read as one produced by the provider the caller named.
+    requested_provider: Optional[str] = Field(
+        default=None,
+        description=(
+            "Provider the caller asked for, when they named one. Differs from "
+            "provider only when a fallback was taken; None when the caller let "
+            "the client choose."
+        ),
+    )
+    provider_attempts: List[ProviderAttempt] = Field(
+        default_factory=list,
+        description=(
+            "Providers tried for this run, in order, and why each failed. "
+            "Describes this run only, so it is never read back from cache."
+        ),
+    )
+
+    @property
+    def fell_back(self) -> bool:
+        """Report whether a provider other than the first choice produced this.
+
+        Returns:
+            True when at least one provider was tried and failed first.
+
+        >>> ResearchResult(markdown="x", provider="openai", query="q").fell_back
+        False
+        >>> ResearchResult(markdown="x", provider="openai", query="q", provider_attempts=[
+        ...     ProviderAttempt(provider="falcon", succeeded=False, reason="402"),
+        ...     ProviderAttempt(provider="openai", succeeded=True),
+        ... ]).fell_back
+        True
+        """
+        return any(not attempt.succeeded for attempt in self.provider_attempts)
+
+    def fallback_frontmatter(self) -> Dict[str, Any]:
+        """Render the fallback provenance for a report's frontmatter.
+
+        Lives here rather than in a formatter because there is more than one
+        formatter, and a fallback that only some reports admit to would be
+        worse than one none of them mention.
+
+        Returns:
+            Frontmatter keys describing the fallback, or an empty dict when no
+            fallback happened -- the presence of these keys is the finding.
+
+        >>> ResearchResult(markdown="x", provider="openai", query="q").fallback_frontmatter()
+        {}
+        >>> result = ResearchResult(
+        ...     markdown="x", provider="openai", query="q", requested_provider="falcon",
+        ...     provider_attempts=[
+        ...         ProviderAttempt(provider="falcon", succeeded=False, reason="402"),
+        ...         ProviderAttempt(provider="openai", succeeded=True),
+        ...     ])
+        >>> result.fallback_frontmatter()["fell_back"]
+        True
+        >>> result.fallback_frontmatter()["requested_provider"]
+        'falcon'
+        >>> result.fallback_frontmatter()["provider_attempts"]
+        [{'provider': 'falcon', 'succeeded': False, 'reason': '402'}, {'provider': 'openai', 'succeeded': True}]
+        """
+        if not self.fell_back:
+            return {}
+        metadata: Dict[str, Any] = {"fell_back": True}
+        if self.requested_provider:
+            metadata["requested_provider"] = self.requested_provider
+        metadata["provider_attempts"] = [
+            attempt.model_dump(exclude_none=True) for attempt in self.provider_attempts
+        ]
+        return metadata
 
 
 class ProviderConfig(BaseModel):

--- a/src/deep_research_client/processing/result_formatter.py
+++ b/src/deep_research_client/processing/result_formatter.py
@@ -81,6 +81,10 @@ class ResultFormatter:
         if result.run_metadata:
             metadata["run_metadata"] = result.run_metadata
 
+        # Record a fallback, and only a fallback: `provider` on its own would
+        # make a report produced by a stand-in read as a deliberate choice.
+        metadata.update(result.fallback_frontmatter())
+
         # Add citation count
         if result.citations:
             metadata["citation_count"] = len(result.citations)

--- a/src/deep_research_client/provider_params.py
+++ b/src/deep_research_client/provider_params.py
@@ -233,6 +233,17 @@ class MockParams(BaseProviderParams):
         default=False,
         description="Whether to simulate an error response"
     )
+    error_type: Optional[
+        Literal["auth", "billing", "quota", "rate_limit", "transient", "not_configured"]
+    ] = Field(
+        default=None,
+        description=(
+            "Simulate a specific typed provider failure instead of a generic "
+            "error. Lets provider fallback be exercised without a real outage: "
+            "auth/billing/quota/not_configured mean this provider cannot do the "
+            "work, while rate_limit/transient mean wait and retry the same one."
+        ),
+    )
     custom_response: Optional[str] = Field(
         default=None,
         description="Custom response text instead of default"

--- a/src/deep_research_client/providers/__init__.py
+++ b/src/deep_research_client/providers/__init__.py
@@ -20,6 +20,14 @@ class ResearchProvider(ABC):
     #: Human-facing name for this provider's credential, e.g. "OpenAI".
     credential_label: ClassVar[Optional[str]] = None
 
+    #: Whether this provider's output is real research. False for a provider
+    #: that fabricates its reports, which keeps it out of the *automatic*
+    #: fallback ordering: a run that ran out of credits should fail rather
+    #: than quietly hand a curation record a made-up report. Naming such a
+    #: provider explicitly still honours it -- that is a deliberate choice,
+    #: not a stand-in nobody asked for.
+    produces_real_reports: ClassVar[bool] = True
+
     def __init__(self, config: ProviderConfig, params_or_model: Optional[Union[str, "BaseProviderParams"]] = None):
         """Initialize provider with configuration.
 

--- a/src/deep_research_client/providers/mock.py
+++ b/src/deep_research_client/providers/mock.py
@@ -30,7 +30,11 @@ from ..provider_params import MockParams
 _SIMULATED_ERRORS: dict[str, tuple[type[ProviderError], Optional[int], dict]] = {
     "auth": (ProviderAuthError, 401, {}),
     "billing": (ProviderBillingError, 402, {}),
-    "quota": (ProviderQuotaError, 429, {"resets_at": "3pm, pool quota_pool_7f21"}),
+    # No status code, matching the real thing: a spent allowance is detected
+    # from the CLI's own wording, so ProviderQuotaError is built without one.
+    # 429 would also read as a contradiction of the documented rule that a 429
+    # means wait rather than switch -- that is ProviderRateLimitError's status.
+    "quota": (ProviderQuotaError, None, {"resets_at": "3pm, pool quota_pool_7f21"}),
     "rate_limit": (ProviderRateLimitError, 429, {}),
     "transient": (ProviderTransientError, 503, {}),
     "not_configured": (ProviderNotConfiguredError, None, {}),

--- a/src/deep_research_client/providers/mock.py
+++ b/src/deep_research_client/providers/mock.py
@@ -37,6 +37,10 @@ _SIMULATED_ERRORS: dict[str, tuple[type[ProviderError], Optional[int], dict]] = 
     "quota": (ProviderQuotaError, None, {"resets_at": "3pm, pool quota_pool_7f21"}),
     "rate_limit": (ProviderRateLimitError, 429, {}),
     "transient": (ProviderTransientError, 503, {}),
+    # Reproduces the error *type* rather than the path: a real
+    # ProviderNotConfiguredError is raised while resolving a provider, before
+    # any research call, so nothing outside this table raises one from here.
+    # Simulating the type is still what a fallback test needs.
     "not_configured": (ProviderNotConfiguredError, None, {}),
 }
 

--- a/src/deep_research_client/providers/mock.py
+++ b/src/deep_research_client/providers/mock.py
@@ -34,6 +34,10 @@ _SIMULATED_ERRORS: dict[str, tuple[type[ProviderError], Optional[int]]] = {
 class MockProvider(ResearchProvider):
     """Mock provider that returns fake responses for testing."""
 
+    #: The reports are invented, so this provider is never fallen back to
+    #: automatically. ``--fallback-provider mock`` still reaches it.
+    produces_real_reports = False
+
     def __init__(self, config: ProviderConfig, params: Optional[MockParams] = None):
         """Initialize Mock provider.
 
@@ -43,10 +47,6 @@ class MockProvider(ResearchProvider):
         """
         self.params = params or MockParams()
         super().__init__(config, self.params.model)
-
-    #: The reports are invented, so this provider is never fallen back to
-    #: automatically. ``--fallback-provider mock`` still reaches it.
-    produces_real_reports = False
 
     def get_default_model(self) -> str:
         """Get default Mock model."""

--- a/src/deep_research_client/providers/mock.py
+++ b/src/deep_research_client/providers/mock.py
@@ -5,8 +5,30 @@ from datetime import datetime
 from typing import List, Optional
 
 from . import ResearchProvider
+from ..exceptions import (
+    ProviderAuthError,
+    ProviderBillingError,
+    ProviderError,
+    ProviderNotConfiguredError,
+    ProviderQuotaError,
+    ProviderRateLimitError,
+    ProviderTransientError,
+)
 from ..models import ResearchResult, ProviderConfig
 from ..provider_params import MockParams
+
+
+#: The failure each ``error_type`` stands for, with the status code a real
+#: provider would have carried it on. Keyed by the same literals MockParams
+#: accepts, so the two cannot drift apart silently.
+_SIMULATED_ERRORS: dict[str, tuple[type[ProviderError], Optional[int]]] = {
+    "auth": (ProviderAuthError, 401),
+    "billing": (ProviderBillingError, 402),
+    "quota": (ProviderQuotaError, 429),
+    "rate_limit": (ProviderRateLimitError, 429),
+    "transient": (ProviderTransientError, 503),
+    "not_configured": (ProviderNotConfiguredError, None),
+}
 
 
 class MockProvider(ResearchProvider):
@@ -40,12 +62,25 @@ class MockProvider(ResearchProvider):
             ResearchResult with mock content and citations
 
         Raises:
+            ProviderError: If error_type names a failure to simulate; the
+                subclass matches the name, so a caller can exercise fallback
+                (auth/billing/quota/not_configured) or its refusal to fall back
+                (rate_limit/transient) without a real outage.
             ValueError: If include_error parameter is True
         """
         # Simulate API delay
         await asyncio.sleep(self.params.response_delay)
 
-        # Simulate error if requested
+        # Simulate error if requested. The typed failure is checked first: it
+        # says more than the generic one, so where a caller asked for both,
+        # answering with the vaguer error would be throwing information away.
+        if self.params.error_type:
+            error_class, status_code = _SIMULATED_ERRORS[self.params.error_type]
+            raise error_class(
+                self.name,
+                f"Mock error: simulated {self.params.error_type} failure",
+                status_code,
+            )
         if self.params.include_error:
             raise ValueError("Mock error: This is a simulated API error for testing")
 

--- a/src/deep_research_client/providers/mock.py
+++ b/src/deep_research_client/providers/mock.py
@@ -18,16 +18,22 @@ from ..models import ResearchResult, ProviderConfig
 from ..provider_params import MockParams
 
 
-#: The failure each ``error_type`` stands for, with the status code a real
-#: provider would have carried it on. Keyed by the same literals MockParams
-#: accepts, so the two cannot drift apart silently.
-_SIMULATED_ERRORS: dict[str, tuple[type[ProviderError], Optional[int]]] = {
-    "auth": (ProviderAuthError, 401),
-    "billing": (ProviderBillingError, 402),
-    "quota": (ProviderQuotaError, 429),
-    "rate_limit": (ProviderRateLimitError, 429),
-    "transient": (ProviderTransientError, 503),
-    "not_configured": (ProviderNotConfiguredError, None),
+#: The failure each ``error_type`` stands for: the class, the status code a
+#: real provider would have carried it on, and any extra the constructor takes.
+#: Keyed by the same literals MockParams accepts, so the two cannot drift apart
+#: silently.
+#:
+#: The quota entry carries a reset time on purpose. ProviderQuotaError is the
+#: one error that folds provider-supplied text into its own remedy, so without
+#: it the mock cannot reproduce the case the report's redaction exists for --
+#: the comma keeps everything after the time, and none of it reaches the file.
+_SIMULATED_ERRORS: dict[str, tuple[type[ProviderError], Optional[int], dict]] = {
+    "auth": (ProviderAuthError, 401, {}),
+    "billing": (ProviderBillingError, 402, {}),
+    "quota": (ProviderQuotaError, 429, {"resets_at": "3pm, pool quota_pool_7f21"}),
+    "rate_limit": (ProviderRateLimitError, 429, {}),
+    "transient": (ProviderTransientError, 503, {}),
+    "not_configured": (ProviderNotConfiguredError, None, {}),
 }
 
 
@@ -79,11 +85,12 @@ class MockProvider(ResearchProvider):
         # says more than the generic one, so where a caller asked for both,
         # answering with the vaguer error would be throwing information away.
         if self.params.error_type:
-            error_class, status_code = _SIMULATED_ERRORS[self.params.error_type]
+            error_class, status_code, extra = _SIMULATED_ERRORS[self.params.error_type]
             raise error_class(
                 self.name,
                 f"Mock error: simulated {self.params.error_type} failure",
                 status_code,
+                **extra,
             )
         if self.params.include_error:
             raise ValueError("Mock error: This is a simulated API error for testing")

--- a/src/deep_research_client/providers/mock.py
+++ b/src/deep_research_client/providers/mock.py
@@ -44,6 +44,10 @@ class MockProvider(ResearchProvider):
         self.params = params or MockParams()
         super().__init__(config, self.params.model)
 
+    #: The reports are invented, so this provider is never fallen back to
+    #: automatically. ``--fallback-provider mock`` still reaches it.
+    produces_real_reports = False
+
     def get_default_model(self) -> str:
         """Get default Mock model."""
         return "mock-model-v1"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -11,10 +11,6 @@ import pytest
 
 from deep_research_client import DeepResearchClient, ResearchResult, ProviderConfig, CacheConfig
 from deep_research_client.providers import ResearchProvider
-from deep_research_client.providers.asta import AstaProvider
-from deep_research_client.providers.falcon import FalconProvider
-from deep_research_client.providers.openscientist import OpenScientistProvider
-from deep_research_client.providers.claude_code import ClaudeCodeProvider
 
 
 class MockProvider(ResearchProvider):
@@ -160,10 +156,7 @@ def test_asta_cache_params_include_version_tag():
     with patch.dict(os.environ, {}, clear=True):
         client = DeepResearchClient(cache_config=cache_config)
 
-    provider = AstaProvider(ProviderConfig(
-        name="asta", api_key="asta-key", enabled=True))
-    cache_params = client._get_cache_provider_params(
-        provider.name, {"paper_limit": 20})
+    cache_params = client._get_cache_provider_params("asta", {"paper_limit": 20})
 
     assert cache_params == {
         "paper_limit": 20,
@@ -177,9 +170,7 @@ def test_falcon_cache_params_include_artifact_version_tag():
     with patch.dict(os.environ, {}, clear=True):
         client = DeepResearchClient(cache_config=cache_config)
 
-    provider = FalconProvider(ProviderConfig(
-        name="falcon", api_key="edison-key", enabled=True))
-    cache_params = client._get_cache_provider_params(provider.name)
+    cache_params = client._get_cache_provider_params("falcon")
 
     assert cache_params == {"_cache_version": "artifacts-v1"}
 
@@ -190,10 +181,7 @@ def test_openscientist_cache_params_include_artifact_version_tag():
     with patch.dict(os.environ, {}, clear=True):
         client = DeepResearchClient(cache_config=cache_config)
 
-    provider = OpenScientistProvider(
-        ProviderConfig(name="openscientist", api_key="opensci-key", enabled=True)
-    )
-    cache_params = client._get_cache_provider_params(provider.name)
+    cache_params = client._get_cache_provider_params("openscientist")
 
     assert cache_params == {"_cache_version": "artifacts-v1"}
 
@@ -204,10 +192,7 @@ def test_claude_code_cache_params_include_version_tag():
     with patch.dict(os.environ, {}, clear=True):
         client = DeepResearchClient(cache_config=cache_config)
 
-    provider = ClaudeCodeProvider(
-        ProviderConfig(name="claude_code", api_key=None, enabled=True)
-    )
-    cache_params = client._get_cache_provider_params(provider.name)
+    cache_params = client._get_cache_provider_params("claude_code")
 
     assert cache_params == {"_cache_version": "inline-report-v1"}
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -163,7 +163,7 @@ def test_asta_cache_params_include_version_tag():
     provider = AstaProvider(ProviderConfig(
         name="asta", api_key="asta-key", enabled=True))
     cache_params = client._get_cache_provider_params(
-        provider, {"paper_limit": 20})
+        provider.name, {"paper_limit": 20})
 
     assert cache_params == {
         "paper_limit": 20,
@@ -179,7 +179,7 @@ def test_falcon_cache_params_include_artifact_version_tag():
 
     provider = FalconProvider(ProviderConfig(
         name="falcon", api_key="edison-key", enabled=True))
-    cache_params = client._get_cache_provider_params(provider)
+    cache_params = client._get_cache_provider_params(provider.name)
 
     assert cache_params == {"_cache_version": "artifacts-v1"}
 
@@ -193,7 +193,7 @@ def test_openscientist_cache_params_include_artifact_version_tag():
     provider = OpenScientistProvider(
         ProviderConfig(name="openscientist", api_key="opensci-key", enabled=True)
     )
-    cache_params = client._get_cache_provider_params(provider)
+    cache_params = client._get_cache_provider_params(provider.name)
 
     assert cache_params == {"_cache_version": "artifacts-v1"}
 
@@ -207,7 +207,7 @@ def test_claude_code_cache_params_include_version_tag():
     provider = ClaudeCodeProvider(
         ProviderConfig(name="claude_code", api_key=None, enabled=True)
     )
-    cache_params = client._get_cache_provider_params(provider)
+    cache_params = client._get_cache_provider_params(provider.name)
 
     assert cache_params == {"_cache_version": "inline-report-v1"}
 

--- a/tests/test_provider_fallback.py
+++ b/tests/test_provider_fallback.py
@@ -1,0 +1,502 @@
+"""Tests for opt-in provider fallback and the provenance it records.
+
+See https://github.com/monarch-initiative/deep-research-client/issues/69
+
+Nothing here is mocked. The failures are produced by the shipped
+:class:`MockProvider`, which raises the same typed errors a real provider
+raises, so the client is exercised through its ordinary code path.
+"""
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from deep_research_client import cli as cli_module
+from deep_research_client.client import DeepResearchClient
+from deep_research_client.exceptions import (
+    FALLBACK_WORTHY_ERRORS,
+    ProviderAuthError,
+    ProviderBillingError,
+    ProviderNotConfiguredError,
+    ProviderQuotaError,
+    ProviderRateLimitError,
+    ProviderTransientError,
+    is_fallback_worthy,
+)
+from deep_research_client.formatter import ResultFormatter as LegacyResultFormatter
+from deep_research_client.processing import ResultFormatter
+from deep_research_client.models import CacheConfig, ProviderConfig
+from deep_research_client.processing import ResearchProcessor
+from deep_research_client.provider_params import MockParams
+from deep_research_client.providers.mock import MockProvider
+
+PRIMARY = "mock"
+BACKUP = "mock_backup"
+SPARE = "mock_spare"
+
+
+def _params(**kwargs) -> MockParams:
+    """Build mock parameters with no artificial delay."""
+    kwargs.setdefault("response_delay", 0.0)
+    return MockParams(**kwargs)
+
+
+def _client(*named_params, cache_dir=None) -> DeepResearchClient:
+    """Build a client whose registry holds exactly the given mock providers.
+
+    Args:
+        named_params: ``(name, MockParams)`` pairs, in registration order.
+        cache_dir: Enable the on-disk cache in this directory when given.
+
+    Returns:
+        A client with no provider except the ones named.
+    """
+    cache_config = CacheConfig(
+        enabled=cache_dir is not None,
+        directory=str(cache_dir) if cache_dir else None,
+    )
+    # Passing provider_configs skips environment detection entirely, so the
+    # registry cannot pick up whatever happens to be configured on this machine.
+    client = DeepResearchClient(
+        cache_config=cache_config,
+        provider_configs={PRIMARY: ProviderConfig(name=PRIMARY)},
+    )
+    for name, params in named_params:
+        client.registry.register(MockProvider(ProviderConfig(name=name), params))
+    return client
+
+
+# --------------------------------------------------------------------------
+# Which failures justify switching provider
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "error, expected",
+    [
+        (ProviderAuthError("p", "bad key", 401), True),
+        (ProviderBillingError("p", "no credits", 402), True),
+        (ProviderQuotaError("p", "limit spent"), True),
+        (ProviderNotConfiguredError("p", "no key"), True),
+        (ProviderRateLimitError("p", "slow down", 429), False),
+        (ProviderTransientError("p", "bad gateway", 502), False),
+        (ValueError("malformed response"), False),
+        (RuntimeError("boom"), False),
+    ],
+)
+def test_only_provider_specific_failures_justify_a_switch(error, expected):
+    """A switch needs evidence that *this* provider cannot do the work."""
+    assert is_fallback_worthy(error) is expected
+
+
+def test_retryable_errors_are_never_fallback_worthy():
+    """The two axes must not be confused: wait-and-retry is not switch-provider."""
+    for error_class in FALLBACK_WORTHY_ERRORS:
+        assert error_class.retryable is False
+
+
+# --------------------------------------------------------------------------
+# The mock provider's typed failures
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "error_type, expected_class",
+    [
+        ("auth", ProviderAuthError),
+        ("billing", ProviderBillingError),
+        ("quota", ProviderQuotaError),
+        ("rate_limit", ProviderRateLimitError),
+        ("transient", ProviderTransientError),
+        ("not_configured", ProviderNotConfiguredError),
+    ],
+)
+def test_mock_provider_raises_the_named_failure(error_type, expected_class):
+    """Each error_type produces the real exception class it names."""
+    client = _client((PRIMARY, _params(error_type=error_type)))
+    with pytest.raises(expected_class):
+        client.research("q")
+
+
+def test_typed_error_wins_over_the_generic_one():
+    """Answering with the vaguer error would throw information away."""
+    client = _client((PRIMARY, _params(error_type="billing", include_error=True)))
+    with pytest.raises(ProviderBillingError):
+        client.research("q")
+
+
+# --------------------------------------------------------------------------
+# Fallback is opt-in
+# --------------------------------------------------------------------------
+
+
+def test_no_fallback_by_default():
+    """Without opting in, a failure propagates even though a backup exists."""
+    client = _client(
+        (PRIMARY, _params(error_type="billing")),
+        (BACKUP, _params()),
+    )
+    with pytest.raises(ProviderBillingError):
+        client.research("q", provider=PRIMARY)
+
+
+def test_default_run_records_who_produced_it_without_claiming_a_fallback():
+    """A single successful provider is recorded, but is not a fallback."""
+    client = _client((PRIMARY, _params()))
+    result = client.research("q", provider=PRIMARY)
+    assert result.provider == PRIMARY
+    assert result.fell_back is False
+    assert [(a.provider, a.succeeded) for a in result.provider_attempts] == [(PRIMARY, True)]
+
+
+def test_fallback_uses_the_next_available_provider():
+    """Opting in lets a second provider produce the report."""
+    client = _client(
+        (PRIMARY, _params(error_type="billing")),
+        (BACKUP, _params()),
+    )
+    result = client.research("q", provider=PRIMARY, fallback=True)
+    assert result.provider == BACKUP
+    assert result.fell_back is True
+
+
+def test_fallback_records_what_was_asked_for_and_what_was_tried():
+    """The trail must name the requested provider and why it was not used."""
+    client = _client(
+        (PRIMARY, _params(error_type="billing")),
+        (BACKUP, _params()),
+    )
+    result = client.research("q", provider=PRIMARY, fallback=True)
+
+    assert result.requested_provider == PRIMARY
+    assert [(a.provider, a.succeeded) for a in result.provider_attempts] == [
+        (PRIMARY, False),
+        (BACKUP, True),
+    ]
+    failure = result.provider_attempts[0]
+    assert failure.error_type == "ProviderBillingError"
+    assert failure.retryable is False
+    assert "out of credits" in failure.reason
+
+
+@pytest.mark.parametrize("error_type", ["rate_limit", "transient"])
+def test_a_wait_and_retry_failure_does_not_switch_provider(error_type):
+    """A throttle or a 5xx says wait, not switch -- even with fallback on."""
+    client = _client(
+        (PRIMARY, _params(error_type=error_type)),
+        (BACKUP, _params()),
+    )
+    with pytest.raises((ProviderRateLimitError, ProviderTransientError)):
+        client.research("q", provider=PRIMARY, fallback=True)
+
+
+def test_an_unclassified_failure_does_not_switch_provider():
+    """An unexplained failure is not evidence that another provider would do."""
+    client = _client(
+        (PRIMARY, _params(include_error=True)),
+        (BACKUP, _params()),
+    )
+    with pytest.raises(ValueError, match="simulated API error"):
+        client.research("q", provider=PRIMARY, fallback=True)
+
+
+# --------------------------------------------------------------------------
+# Ordering and explicit lists
+# --------------------------------------------------------------------------
+
+
+def test_an_explicit_list_sets_the_order():
+    """A named list is an instruction, not a hint."""
+    client = _client(
+        (PRIMARY, _params(error_type="billing")),
+        (BACKUP, _params(error_type="auth")),
+        (SPARE, _params()),
+    )
+    result = client.research("q", provider=PRIMARY, fallback=[BACKUP, SPARE])
+    assert result.provider == SPARE
+    assert [a.provider for a in result.provider_attempts] == [PRIMARY, BACKUP, SPARE]
+
+
+def test_an_explicit_list_can_skip_an_available_provider():
+    """Naming providers replaces the automatic ordering rather than extending it."""
+    client = _client(
+        (PRIMARY, _params(error_type="billing")),
+        (BACKUP, _params()),
+        (SPARE, _params()),
+    )
+    result = client.research("q", provider=PRIMARY, fallback=[SPARE])
+    assert result.provider == SPARE
+    assert BACKUP not in [a.provider for a in result.provider_attempts]
+
+
+def test_a_named_but_unconfigured_provider_is_recorded_not_silently_dropped():
+    """Every name in an explicit list gets an answer in the trail."""
+    client = _client(
+        (PRIMARY, _params(error_type="billing")),
+        (BACKUP, _params()),
+    )
+    result = client.research("q", provider=PRIMARY, fallback=["openai", BACKUP])
+
+    assert result.provider == BACKUP
+    skipped = result.provider_attempts[1]
+    assert skipped.provider == "openai"
+    assert skipped.error_type == "ProviderNotConfiguredError"
+    assert skipped.reason
+
+
+def test_fallback_without_a_named_provider_starts_from_the_first_available():
+    """Letting the client choose still falls back from whatever it chose."""
+    client = _client(
+        (PRIMARY, _params(error_type="quota")),
+        (BACKUP, _params()),
+    )
+    result = client.research("q", fallback=True)
+    assert result.provider == BACKUP
+    assert result.requested_provider is None
+    assert result.fell_back is True
+
+
+# --------------------------------------------------------------------------
+# Exhaustion and fail-closed
+# --------------------------------------------------------------------------
+
+
+def test_the_last_failure_propagates_when_everything_fails():
+    """Exhausting every candidate raises rather than returning a partial result."""
+    client = _client(
+        (PRIMARY, _params(error_type="billing")),
+        (BACKUP, _params(error_type="auth")),
+    )
+    with pytest.raises(ProviderAuthError):
+        client.research("q", provider=PRIMARY, fallback=True)
+
+
+def test_nothing_is_cached_when_every_provider_fails(tmp_path):
+    """Fail-closed: no report exists, so no cache entry may either."""
+    client = _client(
+        (PRIMARY, _params(error_type="billing")),
+        (BACKUP, _params(error_type="auth")),
+        cache_dir=tmp_path,
+    )
+    with pytest.raises(ProviderAuthError):
+        client.research("q", provider=PRIMARY, fallback=True)
+    assert list(tmp_path.glob("*.json")) == []
+
+
+def test_no_providers_at_all_is_still_a_plain_error():
+    """An empty registry reports itself the same way it always did."""
+    client = DeepResearchClient(
+        cache_config=CacheConfig(enabled=False),
+        provider_configs={PRIMARY: ProviderConfig(name=PRIMARY)},
+    )
+    client.registry._providers.clear()
+    with pytest.raises(ValueError, match="No research providers available"):
+        client.research("q", fallback=True)
+
+
+def test_an_unknown_provider_name_is_still_a_plain_error():
+    """A typo must not be reported as a configuration problem."""
+    client = _client((PRIMARY, _params()))
+    with pytest.raises(ValueError, match="not found"):
+        client.research("q", provider="flacon", fallback=True)
+
+
+# --------------------------------------------------------------------------
+# Caching must not inherit another run's provenance
+# --------------------------------------------------------------------------
+
+
+def test_the_cache_does_not_store_which_providers_were_tried(tmp_path):
+    """Attempts describe one run; replaying them would credit a later run."""
+    client = _client(
+        (PRIMARY, _params(error_type="billing")),
+        (BACKUP, _params()),
+        cache_dir=tmp_path,
+    )
+    result = client.research("q", provider=PRIMARY, fallback=True)
+    assert result.fell_back is True
+
+    cached_files = list(tmp_path.glob("*.json"))
+    assert len(cached_files) == 1
+    payload = json.loads(cached_files[0].read_text())
+    assert payload["provider_attempts"] == []
+    assert payload["requested_provider"] is None
+
+
+def test_a_cache_hit_is_stamped_with_this_run_not_the_stored_one(tmp_path):
+    """Reading from cache still records who was asked and who answered."""
+    warm = _client((BACKUP, _params()), cache_dir=tmp_path)
+    warm.research("q", provider=BACKUP)
+
+    client = _client(
+        (PRIMARY, _params(error_type="billing")),
+        (BACKUP, _params()),
+        cache_dir=tmp_path,
+    )
+    result = client.research("q", provider=PRIMARY, fallback=True)
+
+    assert result.cached is True
+    assert result.provider == BACKUP
+    assert result.requested_provider == PRIMARY
+    assert [(a.provider, a.succeeded) for a in result.provider_attempts] == [
+        (PRIMARY, False),
+        (BACKUP, True),
+    ]
+
+
+# --------------------------------------------------------------------------
+# Overrides chosen for one provider are not handed to another
+# --------------------------------------------------------------------------
+
+
+def test_a_fallback_provider_runs_on_its_own_defaults():
+    """A model and parameters chosen for one provider mean nothing to another.
+
+    Without this the run would die on the fallback provider's schema, since
+    provider parameter models reject unknown fields.
+    """
+    client = _client(
+        (PRIMARY, _params(error_type="billing")),
+        (BACKUP, _params()),
+    )
+    # Passing provider_params rebuilds the provider from them, so the failure
+    # has to be requested here too -- the registered instance is replaced.
+    result = client.research(
+        "q",
+        provider=PRIMARY,
+        provider_params={
+            "response_length": "short",
+            "error_type": "billing",
+            "response_delay": 0.0,
+        },
+        model="mock-model-v1",
+        fallback=True,
+    )
+    assert result.provider == BACKUP
+    # The backup's own default length, not the "short" asked of the primary.
+    assert "medium-length mock response" in result.markdown
+
+
+def test_dropping_overrides_is_said_out_loud(caplog):
+    """Changing what was asked for is never silent."""
+    client = _client(
+        (PRIMARY, _params(error_type="billing")),
+        (BACKUP, _params()),
+    )
+    with caplog.at_level("WARNING"):
+        client.research(
+            "q",
+            provider=PRIMARY,
+            provider_params={"error_type": "billing", "response_delay": 0.0},
+            fallback=True,
+        )
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("own defaults" in message for message in messages)
+    assert any("--param" in message for message in messages)
+
+
+# --------------------------------------------------------------------------
+# What the report says
+# --------------------------------------------------------------------------
+
+
+# Both formatters are live surfaces: the CLI writes reports through the
+# processing one, while the top-level one remains importable. A fallback that
+# only one of them admitted to would be worse than one neither mentioned.
+FORMATTERS = [ResultFormatter, LegacyResultFormatter]
+
+
+@pytest.mark.parametrize("formatter_class", FORMATTERS)
+def test_frontmatter_reports_a_fallback(formatter_class):
+    """A curator reading the report must see it came from someone else."""
+    client = _client(
+        (PRIMARY, _params(error_type="billing")),
+        (BACKUP, _params()),
+    )
+    result = client.research("q", provider=PRIMARY, fallback=True)
+    frontmatter = formatter_class().format_full_markdown(result).split("---")[1]
+
+    assert "fell_back: true" in frontmatter
+    assert f"requested_provider: {PRIMARY}" in frontmatter
+    assert "ProviderBillingError" in frontmatter
+
+
+@pytest.mark.parametrize("formatter_class", FORMATTERS)
+def test_frontmatter_is_unchanged_when_no_fallback_happened(formatter_class):
+    """An ordinary report gains nothing: silence is the absence of a finding."""
+    client = _client((PRIMARY, _params()))
+    result = client.research("q", provider=PRIMARY)
+    frontmatter = formatter_class().format_full_markdown(result).split("---")[1]
+
+    assert "fell_back" not in frontmatter
+    assert "provider_attempts" not in frontmatter
+    assert "requested_provider" not in frontmatter
+
+
+def test_the_report_the_cli_writes_admits_the_fallback():
+    """The processor is the path a saved report actually travels."""
+    client = _client(
+        (PRIMARY, _params(error_type="billing")),
+        (BACKUP, _params()),
+    )
+    result = client.research("q", provider=PRIMARY, fallback=True)
+    content = ResearchProcessor().format_research_result(result)
+
+    assert "fell_back: true" in content
+    assert f"requested_provider: {PRIMARY}" in content
+
+
+# --------------------------------------------------------------------------
+# End to end through the CLI
+# --------------------------------------------------------------------------
+
+
+def test_cli_reaches_the_named_fallback_provider(tmp_path, monkeypatch):
+    """The flags are wired end to end, from command line to the second provider.
+
+    ``deeper_med`` is the honest target here: it is a registered stub with no
+    upstream service, so it is always unavailable and always explains itself.
+    That makes it a real second candidate rather than a contrived one.
+    """
+    monkeypatch.setenv("ENABLE_MOCK_PROVIDER", "true")
+    monkeypatch.setenv("DISABLE_CLAUDE_CODE_PROVIDER", "true")
+    output = tmp_path / "report.md"
+
+    result = CliRunner().invoke(
+        cli_module.app,
+        [
+            "research", "q",
+            "--provider", "mock",
+            "--param", "error_type=billing",
+            "--param", "response_delay=0.0",
+            "--fallback-provider", "deeper_med",
+            "--output", str(output),
+            "--no-cache",
+        ],
+    )
+
+    assert result.exit_code == 1
+    # The trail is visible to whoever is watching the run, not just in a file.
+    assert "Falling back to deeper_med" in result.output
+    assert "out of credits" in result.output
+    # And the stub's own explanation is what ends the run, not the mock's.
+    assert "no public API or code release yet" in result.output
+    # Fail-closed: every candidate failed, so no report was written.
+    assert not output.exists()
+
+
+def test_cli_rejects_nothing_when_fallback_is_absent(tmp_path, monkeypatch):
+    """The flag is opt-in: an ordinary run is untouched by any of this."""
+    monkeypatch.setenv("ENABLE_MOCK_PROVIDER", "true")
+    monkeypatch.setenv("DISABLE_CLAUDE_CODE_PROVIDER", "true")
+    output = tmp_path / "report.md"
+
+    result = CliRunner().invoke(
+        cli_module.app,
+        ["research", "q", "--provider", "mock", "--output", str(output), "--no-cache"],
+    )
+
+    assert result.exit_code == 0
+    content = output.read_text()
+    assert "fell_back" not in content

--- a/tests/test_provider_fallback.py
+++ b/tests/test_provider_fallback.py
@@ -317,14 +317,13 @@ def test_the_last_failure_propagates_when_everything_fails():
         client.research("q", provider=PRIMARY, fallback=True)
 
 
-def test_exhausting_every_candidate_chains_to_the_failure_before_it():
-    """A caller who catches the last failure can still see there were others.
+def test_exhausting_every_candidate_carries_the_whole_trail_out():
+    """With no result there is no `provider_attempts` -- so it goes on the error.
 
-    Each earlier `except` exits via `continue`, so by the time the last one
-    raises it is no longer being handled and `__context__` is None. Without
-    chaining, a run that tried three providers is indistinguishable to a caller
-    from one that tried the last -- in a feature whose whole point is recording
-    who was tried.
+    That is the case a caller most wants it: three providers were tried and
+    the exception is all they get. The trail includes the candidate whose
+    failure is being raised, so it describes the run rather than everything
+    before its end.
     """
     client = _client(
         (PRIMARY, _params(error_type="billing")),
@@ -334,17 +333,54 @@ def test_exhausting_every_candidate_chains_to_the_failure_before_it():
     with pytest.raises(ProviderQuotaError) as caught:
         client.research("q", provider=PRIMARY, fallback=[BACKUP, SPARE])
 
-    # The type and traceback the caller would have had with no fallback at
-    # all are preserved; the cause is what is added.
-    assert isinstance(caught.value.__cause__, ProviderAuthError)
+    assert [a.provider for a in caught.value.provider_attempts] == [
+        PRIMARY, BACKUP, SPARE
+    ]
+    assert [a.error_type for a in caught.value.provider_attempts] == [
+        "ProviderBillingError", "ProviderAuthError", "ProviderQuotaError"
+    ]
 
 
-def test_a_lone_failure_is_not_given_a_spurious_cause():
-    """Chaining must not invent a predecessor where there was none."""
+def test_the_trail_does_not_take_the_cause_a_provider_set_itself():
+    """Three shipped providers do `raise classified from e`; that must survive.
+
+    No other test can see this: every provider in this file raises bare, so
+    `__cause__` is always free to take. Chaining the trail onto it displaced
+    the upstream SDK error to `__context__`, where `__suppress_context__`
+    hides it from the printed traceback -- losing the one frame an operator
+    needs to see what the API actually said.
+    """
+
+    class ChainsItsOwnCause(StandInProvider):
+        """A provider that classifies an SDK failure, as the real ones do."""
+
+        async def research(self, query):
+            try:
+                raise RuntimeError("upstream SDK said 402")
+            except RuntimeError as sdk_error:
+                raise ProviderBillingError(self.name, "no credits", 402) from sdk_error
+
+    client = _client((PRIMARY, _params(error_type="auth")))
+    client.registry.register(ChainsItsOwnCause(ProviderConfig(name=BACKUP), _params()))
+
+    with pytest.raises(ProviderBillingError) as caught:
+        client.research("q", provider=PRIMARY, fallback=[BACKUP])
+
+    # The provider's own `raise ... from` also sets __suppress_context__, so
+    # __cause__ is the assertion that matters: it is still the SDK error and
+    # not the previous candidate.
+    assert isinstance(caught.value.__cause__, RuntimeError)
+    # And the trail is still carried, on its own attribute.
+    assert [a.provider for a in caught.value.provider_attempts] == [PRIMARY, BACKUP]
+
+
+def test_a_lone_failure_carries_no_trail():
+    """One provider is not a trail, and must not read as one."""
     client = _client((PRIMARY, _params(error_type="billing")))
     with pytest.raises(ProviderBillingError) as caught:
         client.research("q", provider=PRIMARY)
 
+    assert caught.value.provider_attempts == ()
     assert caught.value.__cause__ is None
     assert caught.value.__context__ is None
 
@@ -616,6 +652,37 @@ def test_naming_the_mock_reaches_its_cache_even_with_the_gate_off(tmp_path, monk
     assert result.provider == "mock"
     assert result.cached is True
     assert result.fell_back is False
+
+
+def test_a_later_unreachable_candidate_also_answers_from_its_own_cache(tmp_path):
+    """The cached-serve path runs at any non-last position, not only the first.
+
+    At position > 0 the earlier failures are recorded and `fell_back` is true,
+    but the serving candidate's own unreachability is not -- the same as at
+    position 0. Pinned because nothing else exercises the interaction between
+    that read and an already-populated trail.
+    """
+    # `falcon`, not a mock name: the middle candidate has to be known-but-
+    # unregistered so it raises ProviderNotConfiguredError rather than being
+    # rejected up front as a typo.
+    warm = _client(("falcon", _params()), cache_dir=tmp_path)
+    warm.research("q", provider="falcon")
+
+    client = _client(
+        (PRIMARY, _params(error_type="billing")),
+        (SPARE, _params()),
+        cache_dir=tmp_path,
+    )
+    result = client.research("q", provider=PRIMARY, fallback=["falcon", SPARE])
+
+    assert result.provider == "falcon"
+    assert result.cached is True
+    assert result.fell_back is True
+    # The earlier failure is recorded; the server's own unreachability is not.
+    assert [(a.provider, a.succeeded) for a in result.provider_attempts] == [
+        (PRIMARY, False),
+        ("falcon", True),
+    ]
 
 
 @pytest.mark.parametrize("no_fallback", [False, None], ids=["false", "none"])

--- a/tests/test_provider_fallback.py
+++ b/tests/test_provider_fallback.py
@@ -501,6 +501,44 @@ def test_a_cache_hit_is_stamped_with_this_run_not_the_stored_one(tmp_path):
     ]
 
 
+def test_a_cached_report_is_served_even_from_a_provider_we_cannot_reach(tmp_path):
+    """Reading a report off disk needs no credential.
+
+    The cache is consulted per candidate before that candidate is prepared, so
+    a provider whose key has gone still answers from a report it produced
+    earlier -- rather than the run paying the next provider for one we already
+    have. Reachable because the CLI now stands its availability check down
+    whenever a fallback was asked for.
+    """
+    # A falcon report is cached while falcon is configured.
+    warm = _client(("falcon", _params()), cache_dir=tmp_path)
+    warm.research("q", provider="falcon")
+
+    # Later the credential is gone, so falcon cannot be prepared at all.
+    later = _client((BACKUP, _params()), cache_dir=tmp_path)
+    assert "falcon" not in [p.name for p in later.registry.get_available_providers()]
+
+    result = later.research("q", provider="falcon", fallback=[BACKUP])
+
+    assert result.provider == "falcon"
+    assert result.cached is True
+    # No fallback happened, so the report claims nothing it should not.
+    assert result.fell_back is False
+    assert [(a.provider, a.succeeded) for a in result.provider_attempts] == [
+        ("falcon", True)
+    ]
+
+
+def test_an_unreachable_provider_with_no_cache_still_falls_back(tmp_path):
+    """The cache-first lookup must not swallow the fallback it sits in front of."""
+    client = _client((BACKUP, _params()), cache_dir=tmp_path)
+    result = client.research("uncached query", provider="falcon", fallback=[BACKUP])
+
+    assert result.provider == BACKUP
+    assert result.fell_back is True
+    assert result.provider_attempts[0].error_type == "ProviderNotConfiguredError"
+
+
 @pytest.mark.parametrize("warm_the_cache", [False, True], ids=["cold", "warm"])
 def test_a_fallback_is_announced_whether_or_not_the_answer_was_cached(
     tmp_path, caplog, warm_the_cache

--- a/tests/test_provider_fallback.py
+++ b/tests/test_provider_fallback.py
@@ -26,7 +26,12 @@ from deep_research_client.exceptions import (
 )
 from deep_research_client.formatter import ResultFormatter as LegacyResultFormatter
 from deep_research_client.processing import ResultFormatter
-from deep_research_client.models import CacheConfig, ProviderConfig
+from deep_research_client.models import (
+    CacheConfig,
+    ProviderAttempt,
+    ProviderConfig,
+    ResearchResult,
+)
 from deep_research_client.processing import ResearchProcessor
 from deep_research_client.provider_params import MockParams
 from deep_research_client.providers.mock import MockProvider
@@ -500,26 +505,15 @@ def test_a_fallback_is_announced_whether_or_not_the_answer_was_cached(
     assert BACKUP in announcements[0] and PRIMARY in announcements[0]
 
 
-def test_no_fallback_is_announced_when_none_happened():
+def test_no_fallback_is_announced_when_none_happened(caplog):
     """The warning must not fire on an ordinary run."""
     client = _client((PRIMARY, _params()))
-    import logging as _logging
-
-    records = []
-
-    class _Capture(_logging.Handler):
-        def emit(self, record):
-            records.append(record.getMessage())
-
-    handler = _Capture()
-    logger = _logging.getLogger("deep_research_client.client")
-    logger.addHandler(handler)
-    try:
+    with caplog.at_level("WARNING"):
         client.research("q", provider=PRIMARY)
-    finally:
-        logger.removeHandler(handler)
 
-    assert not any("not the provider first tried" in m for m in records)
+    assert not [
+        r for r in caplog.records if "not the provider first tried" in r.getMessage()
+    ]
 
 
 # --------------------------------------------------------------------------
@@ -635,6 +629,35 @@ def test_frontmatter_is_unchanged_when_no_fallback_happened(formatter_class):
     assert "fell_back" not in frontmatter
     assert "provider_attempts" not in frontmatter
     assert "requested_provider" not in frontmatter
+
+
+@pytest.mark.parametrize("formatter_class", FORMATTERS)
+def test_the_report_never_carries_the_providers_own_error_text(formatter_class):
+    """A 401 body is the one most likely to quote the credential it rejected.
+
+    These reports get committed, so the frontmatter carries our reading of the
+    failure, never the provider's prose. The full text stays on the object and
+    in the logs, where it was before any of this reached disk.
+    """
+    secret = "sk-live-NOTAREALKEY123456"
+    leaked = ProviderAuthError("falcon", f"Invalid API key: {secret}", 401)
+    result = ResearchResult(
+        markdown="body", provider=BACKUP, query="q", requested_provider="falcon",
+        provider_attempts=[
+            ProviderAttempt.from_exception("falcon", leaked),
+            ProviderAttempt(provider=BACKUP, succeeded=True),
+        ],
+    )
+    rendered = formatter_class().format_full_markdown(result)
+
+    assert secret not in rendered
+    assert "Invalid API key" not in rendered
+    # What justifies the switch survives, in words we chose.
+    assert "ProviderAuthError" in rendered
+    assert "status_code: 401" in rendered
+    assert "lacks access to this endpoint" in rendered
+    # And the object still has the whole thing for a caller who wants it.
+    assert secret in result.provider_attempts[0].reason
 
 
 def test_the_report_the_cli_writes_admits_the_fallback():

--- a/tests/test_provider_fallback.py
+++ b/tests/test_provider_fallback.py
@@ -799,6 +799,109 @@ def test_cli_reports_the_trail_on_a_successful_fallback(tmp_path, monkeypatch):
     assert "simulated billing failure" not in content
 
 
+def _cli_client_with(*named_params):
+    """Build a substitute for the client the research command constructs.
+
+    See `test_cli_reports_the_trail_on_a_successful_fallback` for why the
+    substitution is needed and what it does and does not replace.
+    """
+    real_client_class = cli_module.DeepResearchClient
+
+    def _factory(cache_config=None, provider_configs=None):
+        client = real_client_class(
+            cache_config=cache_config,
+            provider_configs={PRIMARY: ProviderConfig(name=PRIMARY)},
+        )
+        for name, params in named_params:
+            client.registry.register(StandInProvider(ProviderConfig(name=name), params))
+        return client
+
+    return _factory
+
+
+def test_cli_falls_back_when_the_named_provider_is_not_configured(tmp_path, monkeypatch):
+    """The row the docs list, on the surface most people use.
+
+    The command checks the named provider against the registry before calling
+    the client at all. That check has to stand down when a fallback was asked
+    for, or the CLI refuses what the library allows -- and "not configured" is
+    one of the failures a fallback exists to handle.
+    """
+    monkeypatch.setattr(
+        cli_module, "DeepResearchClient", _cli_client_with((BACKUP, _params()))
+    )
+    output = tmp_path / "report.md"
+
+    result = CliRunner().invoke(
+        cli_module.app,
+        [
+            "research", "q",
+            "--provider", "falcon",
+            "--fallback-provider", BACKUP,
+            "--output", str(output),
+            "--no-cache",
+        ],
+    )
+
+    assert result.exit_code == 0
+    content = output.read_text()
+    assert f"provider: {BACKUP}" in content
+    assert "requested_provider: falcon" in content
+    # The provider that could not run is in the trail, not dropped from it.
+    assert "ProviderNotConfiguredError" in content
+
+
+def test_cli_still_refuses_an_unconfigured_provider_without_a_fallback(tmp_path, monkeypatch):
+    """Standing the check down is conditional on having somewhere else to go."""
+    monkeypatch.setattr(
+        cli_module, "DeepResearchClient", _cli_client_with((BACKUP, _params()))
+    )
+    output = tmp_path / "report.md"
+
+    result = CliRunner().invoke(
+        cli_module.app,
+        ["research", "q", "--provider", "falcon", "--output", str(output), "--no-cache"],
+    )
+
+    assert result.exit_code == 1
+    assert "not available" in result.output
+    assert not output.exists()
+
+
+def test_the_mock_can_demonstrate_the_quota_redaction_end_to_end(tmp_path, monkeypatch):
+    """The one error type that folds provider text into its own remedy.
+
+    Constructing ProviderQuotaError directly tests the redaction, but leaves
+    the guard with no route a reader can run. This is that route.
+    """
+    monkeypatch.setattr(
+        cli_module, "DeepResearchClient", _cli_client_with((BACKUP, _params()))
+    )
+    output = tmp_path / "report.md"
+
+    result = CliRunner().invoke(
+        cli_module.app,
+        [
+            "research", "q",
+            "--provider", PRIMARY,
+            "--param", "error_type=quota",
+            "--param", "response_delay=0.0",
+            "--fallback-provider", BACKUP,
+            "--output", str(output),
+            "--no-cache",
+        ],
+    )
+
+    assert result.exit_code == 0
+    # The console keeps the provider's reset text, identifier and all.
+    assert "quota_pool_7f21" in result.output
+    # The committed file keeps only our reading of it.
+    content = output.read_text()
+    assert "quota_pool_7f21" not in content
+    assert "renews at" not in content
+    assert "the plan's usage limit is spent" in content
+
+
 def test_cli_rejects_nothing_when_fallback_is_absent(tmp_path, monkeypatch):
     """The flag is opt-in: an ordinary run is untouched by any of this."""
     monkeypatch.setenv("ENABLE_MOCK_PROVIDER", "true")

--- a/tests/test_provider_fallback.py
+++ b/tests/test_provider_fallback.py
@@ -660,6 +660,33 @@ def test_the_report_never_carries_the_providers_own_error_text(formatter_class):
     assert secret in result.provider_attempts[0].reason
 
 
+@pytest.mark.parametrize("formatter_class", FORMATTERS)
+def test_a_quota_resets_at_does_not_reach_the_report(formatter_class):
+    """The one error type that sharpens its own remedy with provider text.
+
+    `_LIMIT_RESET` stops at a full stop or semicolon but deliberately keeps
+    commas, so "10am, Tuesday 19 August" survives as one time -- and so does
+    anything else comma-separated after it, up to the character cap.
+    """
+    spent = ProviderQuotaError(
+        "claude_code", "usage limit reached", resets_at="10am, acct_9f3b21c7ee"
+    )
+    result = ResearchResult(
+        markdown="body", provider=BACKUP, query="q", requested_provider="claude_code",
+        provider_attempts=[
+            ProviderAttempt.from_exception("claude_code", spent),
+            ProviderAttempt(provider=BACKUP, succeeded=True),
+        ],
+    )
+    rendered = formatter_class().format_full_markdown(result)
+
+    assert "acct_9f3b21c7ee" not in rendered
+    assert "renews at" not in rendered
+    assert "the plan's usage limit is spent" in rendered
+    # Still on the object, for whoever is actually debugging the outage.
+    assert "acct_9f3b21c7ee" in result.provider_attempts[0].reason
+
+
 def test_the_report_the_cli_writes_admits_the_fallback():
     """The processor is the path a saved report actually travels."""
     client = _client(
@@ -710,6 +737,66 @@ def test_cli_reaches_the_named_fallback_provider(tmp_path, monkeypatch):
     assert "no public API or code release yet" in result.output
     # Fail-closed: every candidate failed, so no report was written.
     assert not output.exists()
+
+
+def test_cli_reports_the_trail_on_a_successful_fallback(tmp_path, monkeypatch):
+    """The CLI's own fallback output, which no other test reaches.
+
+    `test_cli_reaches_the_named_fallback_provider` ends in exit code 1, so the
+    `if result.fell_back:` branch never runs there -- deleting it would fail
+    nothing. Reaching it needs two *available* providers, and no environment a
+    test can arrange gives the CLI that: `mock` is the only one without a
+    credential, and the rest would make real network calls.
+
+    So the client the command builds is substituted for one registered with two
+    real providers. Nothing is mocked in the `unittest.mock` sense -- the CLI,
+    the client, both providers, the formatter and the file write all run for
+    real; only the wiring between two of them is redirected.
+    """
+    real_client_class = cli_module.DeepResearchClient
+
+    def _two_providers(cache_config=None, provider_configs=None):
+        # provider_configs is passed deliberately, not forwarded: it skips
+        # environment detection, so whatever this machine happens to have
+        # configured cannot join the ordering. Without it the fallback found
+        # the `claude` CLI on PATH and made a real subprocess call.
+        client = real_client_class(
+            cache_config=cache_config,
+            provider_configs={PRIMARY: ProviderConfig(name=PRIMARY)},
+        )
+        client.registry.register(
+            StandInProvider(ProviderConfig(name=PRIMARY), _params(error_type="billing"))
+        )
+        client.registry.register(
+            StandInProvider(ProviderConfig(name=BACKUP), _params())
+        )
+        return client
+
+    monkeypatch.setattr(cli_module, "DeepResearchClient", _two_providers)
+    output = tmp_path / "report.md"
+
+    result = CliRunner().invoke(
+        cli_module.app,
+        [
+            "research", "q",
+            "--provider", PRIMARY,
+            "--fallback",
+            "--output", str(output),
+            "--no-cache",
+        ],
+    )
+
+    assert result.exit_code == 0
+    # The client states the switch; the CLI adds the trail. Neither repeats
+    # the other, which is what the de-duplication was for.
+    assert "not the provider first tried" in result.output
+    assert "Providers tried:" in result.output
+    assert f"{BACKUP}: produced the report" in result.output
+    # The console keeps the provider's own words; the report does not.
+    assert "simulated billing failure" in result.output
+    content = output.read_text()
+    assert "fell_back: true" in content
+    assert "simulated billing failure" not in content
 
 
 def test_cli_rejects_nothing_when_fallback_is_absent(tmp_path, monkeypatch):

--- a/tests/test_provider_fallback.py
+++ b/tests/test_provider_fallback.py
@@ -405,6 +405,35 @@ def test_an_unclassified_terminal_failure_logs_the_trail_instead(caplog):
     assert PRIMARY in trail[0] and BACKUP in trail[0]
 
 
+def test_an_unclassified_failure_before_the_last_candidate_names_itself(caplog):
+    """An unclassified failure ends the run wherever it happens.
+
+    It is not fallback-worthy, so the loop stops even with candidates behind
+    it -- and the log must not tell an operator that every provider failed
+    when the last one was never reached.
+    """
+
+    class UnclassifiableFailure(StandInProvider):
+        """A provider whose SDK error nothing recognises."""
+
+        async def research(self, query):
+            raise RuntimeError("connection reset by peer")
+
+    client = _client((PRIMARY, _params(error_type="billing")), (SPARE, _params()))
+    client.registry.register(UnclassifiableFailure(ProviderConfig(name=BACKUP), _params()))
+
+    with caplog.at_level("WARNING"):
+        with pytest.raises(RuntimeError):
+            client.research("q", provider=PRIMARY, fallback=[BACKUP, SPARE])
+
+    trail = [r.getMessage() for r in caplog.records if "Providers tried" in r.getMessage()]
+    assert len(trail) == 1
+    # The candidate that ended the run, not a claim about the whole list.
+    assert f"Provider {BACKUP} failed with RuntimeError" in trail[0]
+    # SPARE was never reached, so it must not appear as an attempt.
+    assert SPARE not in trail[0]
+
+
 def test_a_lone_failure_carries_no_trail():
     """One provider is not a trail, and must not read as one."""
     client = _client((PRIMARY, _params(error_type="billing")))

--- a/tests/test_provider_fallback.py
+++ b/tests/test_provider_fallback.py
@@ -529,6 +529,24 @@ def test_a_cached_report_is_served_even_from_a_provider_we_cannot_reach(tmp_path
     ]
 
 
+def test_without_a_fallback_an_unreachable_provider_still_raises(tmp_path):
+    """The default path must not quietly gain cache-before-credential reads.
+
+    The cache is consulted for a provider that cannot be prepared only when a
+    later candidate would otherwise be billed for a report we already hold.
+    With no fallback there is nobody to bill, so the run fails exactly as it
+    did before any of this -- which also keeps `ENABLE_MOCK_PROVIDER` gating a
+    cached mock report, and keeps the CLI and the library agreeing about what
+    an unconfigured provider does.
+    """
+    warm = _client(("falcon", _params()), cache_dir=tmp_path)
+    warm.research("q", provider="falcon")
+
+    later = _client((BACKUP, _params()), cache_dir=tmp_path)
+    with pytest.raises(ProviderNotConfiguredError):
+        later.research("q", provider="falcon")
+
+
 def test_an_unreachable_provider_with_no_cache_still_falls_back(tmp_path):
     """The cache-first lookup must not swallow the fallback it sits in front of."""
     client = _client((BACKUP, _params()), cache_dir=tmp_path)

--- a/tests/test_provider_fallback.py
+++ b/tests/test_provider_fallback.py
@@ -34,7 +34,7 @@ from deep_research_client.models import (
 )
 from deep_research_client.processing import ResearchProcessor
 from deep_research_client.provider_params import MockParams
-from deep_research_client.providers.mock import MockProvider
+from deep_research_client.providers.mock import _SIMULATED_ERRORS, MockProvider
 
 PRIMARY = "mock"
 BACKUP = "mock_backup"
@@ -135,6 +135,33 @@ def test_mock_provider_raises_the_named_failure(error_type, expected_class):
     client = _client((PRIMARY, _params(error_type=error_type)))
     with pytest.raises(expected_class):
         client.research("q")
+
+
+def test_the_mocks_quota_failure_has_the_shape_a_real_one_has():
+    """The mock exists to show real behaviour, so it must not invent a shape.
+
+    A real spent allowance is recognised from the CLI's own wording and carries
+    no status code. Giving the mock a 429 made its report entry disagree with
+    every real one -- and with the documented rule that a 429 means wait for
+    the same provider rather than switch, which is a different error class.
+
+    Compared against the real classifier rather than a hardcoded shape, so the
+    two cannot drift apart.
+    """
+    from deep_research_client.providers import claude_code
+
+    real = claude_code._classify_cli_failure(
+        "claude_code", "Usage limit reached. Your limit will reset at 3pm."
+    )
+    assert isinstance(real, ProviderQuotaError)
+
+    error_class, status_code, extra = _SIMULATED_ERRORS["quota"]
+    simulated = error_class("mock", "simulated quota failure", status_code, **extra)
+
+    real_entry = ProviderAttempt.from_exception("x", real).frontmatter_entry()
+    mock_entry = ProviderAttempt.from_exception("x", simulated).frontmatter_entry()
+    assert sorted(real_entry) == sorted(mock_entry)
+    assert "status_code" not in mock_entry
 
 
 def test_typed_error_wins_over_the_generic_one():

--- a/tests/test_provider_fallback.py
+++ b/tests/test_provider_fallback.py
@@ -504,11 +504,11 @@ def test_a_cache_hit_is_stamped_with_this_run_not_the_stored_one(tmp_path):
 def test_a_cached_report_is_served_even_from_a_provider_we_cannot_reach(tmp_path):
     """Reading a report off disk needs no credential.
 
-    The cache is consulted per candidate before that candidate is prepared, so
-    a provider whose key has gone still answers from a report it produced
-    earlier -- rather than the run paying the next provider for one we already
-    have. Reachable because the CLI now stands its availability check down
-    whenever a fallback was asked for.
+    On a fallback-worthy preparation failure, and only while another candidate
+    remains, that candidate's cache is consulted before the next provider is
+    called -- so a provider whose key has gone still answers from a report it
+    produced earlier. Reachable because the CLI now stands its availability
+    check down whenever a fallback was asked for.
     """
     # A falcon report is cached while falcon is configured.
     warm = _client(("falcon", _params()), cache_dir=tmp_path)
@@ -532,12 +532,13 @@ def test_a_cached_report_is_served_even_from_a_provider_we_cannot_reach(tmp_path
 def test_without_a_fallback_an_unreachable_provider_still_raises(tmp_path):
     """The default path must not quietly gain cache-before-credential reads.
 
-    The cache is consulted for a provider that cannot be prepared only when a
-    later candidate would otherwise be billed for a report we already hold.
-    With no fallback there is nobody to bill, so the run fails exactly as it
-    did before any of this -- which also keeps `ENABLE_MOCK_PROVIDER` gating a
-    cached mock report, and keeps the CLI and the library agreeing about what
-    an unconfigured provider does.
+    The cache is consulted for a provider that cannot be prepared only while
+    another candidate remains. With no fallback there is none, so the run fails
+    exactly as it did before any of this -- which keeps the CLI and the library
+    agreeing about what an unconfigured provider does.
+
+    `ENABLE_MOCK_PROVIDER` still gates a cached mock report on *this* path.
+    It does not on the fallback path; see the test below, which pins both.
     """
     warm = _client(("falcon", _params()), cache_dir=tmp_path)
     warm.research("q", provider="falcon")
@@ -545,6 +546,37 @@ def test_without_a_fallback_an_unreachable_provider_still_raises(tmp_path):
     later = _client((BACKUP, _params()), cache_dir=tmp_path)
     with pytest.raises(ProviderNotConfiguredError):
         later.research("q", provider="falcon")
+
+
+def test_naming_the_mock_reaches_its_cache_even_with_the_gate_off(tmp_path, monkeypatch):
+    """What ENABLE_MOCK_PROVIDER does and does not gate, pinned on both paths.
+
+    The gate keeps `mock` from being *chosen*, and `produces_real_reports`
+    keeps it out of the automatic ordering. Neither is a rule about reading a
+    report you already have from a provider you named yourself -- so with a
+    fallback requested, the cached mock report is served, and says it came
+    from mock.
+
+    Recorded as a decision rather than left to be discovered: an earlier commit
+    message of mine claimed the narrowing restored this gate outright, which is
+    true only of the no-fallback path above.
+    """
+    monkeypatch.setenv("ENABLE_MOCK_PROVIDER", "true")
+    monkeypatch.setenv("DISABLE_CLAUDE_CODE_PROVIDER", "true")
+    cache = CacheConfig(enabled=True, directory=str(tmp_path))
+    DeepResearchClient(cache_config=cache).research("q", provider="mock")
+
+    monkeypatch.delenv("ENABLE_MOCK_PROVIDER")
+    client = DeepResearchClient(cache_config=cache)
+    assert client.registry.get_provider("mock") is None
+
+    with pytest.raises(ProviderNotConfiguredError):
+        client.research("q", provider="mock")
+
+    result = client.research("q", provider="mock", fallback=["openai"])
+    assert result.provider == "mock"
+    assert result.cached is True
+    assert result.fell_back is False
 
 
 def test_an_unreachable_provider_with_no_cache_still_falls_back(tmp_path):

--- a/tests/test_provider_fallback.py
+++ b/tests/test_provider_fallback.py
@@ -501,7 +501,7 @@ def test_a_cache_hit_is_stamped_with_this_run_not_the_stored_one(tmp_path):
     ]
 
 
-def test_a_cached_report_is_served_even_from_a_provider_we_cannot_reach(tmp_path):
+def test_a_cached_report_is_served_even_from_a_provider_we_cannot_reach(tmp_path, caplog):
     """Reading a report off disk needs no credential.
 
     On a fallback-worthy preparation failure, and only while another candidate
@@ -518,10 +518,17 @@ def test_a_cached_report_is_served_even_from_a_provider_we_cannot_reach(tmp_path
     later = _client((BACKUP, _params()), cache_dir=tmp_path)
     assert "falcon" not in [p.name for p in later.registry.get_available_providers()]
 
-    result = later.research("q", provider="falcon", fallback=[BACKUP])
+    with caplog.at_level("WARNING"):
+        result = later.research("q", provider="falcon", fallback=[BACKUP])
 
     assert result.provider == "falcon"
     assert result.cached is True
+    # The run succeeds, but the revoked credential is still the operator's
+    # news -- the next uncached query will fail. Nothing else on this path
+    # records it: no attempt is appended, because the cached report really
+    # was produced by falcon.
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("falcon" in m and "not configured" in m for m in messages)
     # No fallback happened, so the report claims nothing it should not.
     assert result.fell_back is False
     assert [(a.provider, a.succeeded) for a in result.provider_attempts] == [
@@ -577,6 +584,22 @@ def test_naming_the_mock_reaches_its_cache_even_with_the_gate_off(tmp_path, monk
     assert result.provider == "mock"
     assert result.cached is True
     assert result.fell_back is False
+
+
+@pytest.mark.parametrize("no_fallback", [False, None], ids=["false", "none"])
+def test_no_fallback_is_spelled_two_ways(no_fallback):
+    """None arrives the same way the bare string did, and means the same as False.
+
+    A wrapper passing `config.get("fallback")` for an absent key would
+    otherwise reach `list(None)` and get a TypeError from inside the client
+    naming nothing.
+    """
+    client = _client(
+        (PRIMARY, _params(error_type="billing")),
+        (BACKUP, _params()),
+    )
+    with pytest.raises(ProviderBillingError):
+        client.research("q", provider=PRIMARY, fallback=no_fallback)
 
 
 def test_an_unreachable_provider_with_no_cache_still_falls_back(tmp_path):

--- a/tests/test_provider_fallback.py
+++ b/tests/test_provider_fallback.py
@@ -469,6 +469,59 @@ def test_a_cache_hit_is_stamped_with_this_run_not_the_stored_one(tmp_path):
     ]
 
 
+@pytest.mark.parametrize("warm_the_cache", [False, True], ids=["cold", "warm"])
+def test_a_fallback_is_announced_whether_or_not_the_answer_was_cached(
+    tmp_path, caplog, warm_the_cache
+):
+    """A cached answer is still someone else's answer.
+
+    The two return paths are easy to let drift: the CLI reads `fell_back` so
+    it warned on both, which is why nothing noticed that the library warned
+    only on the cold one.
+    """
+    if warm_the_cache:
+        _client((BACKUP, _params()), cache_dir=tmp_path).research("q", provider=BACKUP)
+
+    client = _client(
+        (PRIMARY, _params(error_type="billing")),
+        (BACKUP, _params()),
+        cache_dir=tmp_path,
+    )
+    with caplog.at_level("WARNING"):
+        result = client.research("q", provider=PRIMARY, fallback=True)
+
+    assert result.cached is warm_the_cache
+    assert result.fell_back is True
+    announcements = [
+        m for m in (r.getMessage() for r in caplog.records)
+        if "not the provider first tried" in m
+    ]
+    assert len(announcements) == 1
+    assert BACKUP in announcements[0] and PRIMARY in announcements[0]
+
+
+def test_no_fallback_is_announced_when_none_happened():
+    """The warning must not fire on an ordinary run."""
+    client = _client((PRIMARY, _params()))
+    import logging as _logging
+
+    records = []
+
+    class _Capture(_logging.Handler):
+        def emit(self, record):
+            records.append(record.getMessage())
+
+    handler = _Capture()
+    logger = _logging.getLogger("deep_research_client.client")
+    logger.addHandler(handler)
+    try:
+        client.research("q", provider=PRIMARY)
+    finally:
+        logger.removeHandler(handler)
+
+    assert not any("not the provider first tried" in m for m in records)
+
+
 # --------------------------------------------------------------------------
 # Overrides chosen for one provider are not handed to another
 # --------------------------------------------------------------------------

--- a/tests/test_provider_fallback.py
+++ b/tests/test_provider_fallback.py
@@ -374,6 +374,37 @@ def test_the_trail_does_not_take_the_cause_a_provider_set_itself():
     assert [a.provider for a in caught.value.provider_attempts] == [PRIMARY, BACKUP]
 
 
+def test_an_unclassified_terminal_failure_logs_the_trail_instead(caplog):
+    """A failure we did not classify has nowhere to carry the trail.
+
+    `openai.py` re-raises bare what `_classify_openai_error` cannot recognise,
+    so a plain SDK error really does reach the loop -- and a plain exception
+    has no field for this. Reading `err.provider_attempts` there is an
+    AttributeError, not an empty trail, so the run says it in the log instead
+    of losing it.
+    """
+
+    class UnclassifiableFailure(StandInProvider):
+        """A provider whose SDK error nothing recognises."""
+
+        async def research(self, query):
+            raise RuntimeError("connection reset by peer")
+
+    client = _client((PRIMARY, _params(error_type="billing")))
+    client.registry.register(UnclassifiableFailure(ProviderConfig(name=BACKUP), _params()))
+
+    with caplog.at_level("WARNING"):
+        with pytest.raises(RuntimeError) as caught:
+            client.research("q", provider=PRIMARY, fallback=[BACKUP])
+
+    # Nothing to attach it to, so the caller must not be told there is.
+    assert not hasattr(caught.value, "provider_attempts")
+    messages = [r.getMessage() for r in caplog.records]
+    trail = [m for m in messages if "Providers tried" in m]
+    assert len(trail) == 1
+    assert PRIMARY in trail[0] and BACKUP in trail[0]
+
+
 def test_a_lone_failure_carries_no_trail():
     """One provider is not a trail, and must not read as one."""
     client = _client((PRIMARY, _params(error_type="billing")))
@@ -1163,6 +1194,40 @@ def test_the_mock_can_demonstrate_the_quota_redaction_end_to_end(tmp_path, monke
     assert "quota_pool_7f21" not in content
     assert "renews at" not in content
     assert "the plan's usage limit is spent" in content
+
+
+def test_cli_shows_the_trail_when_every_candidate_fails(tmp_path, monkeypatch):
+    """The worst case should be as legible as the best.
+
+    The CLI prints `Providers tried:` when a fallback *succeeds*; without this
+    it printed only the last provider's message when the whole run failed --
+    saying more about who was tried when it worked than when it did not.
+    """
+    monkeypatch.setattr(
+        cli_module,
+        "DeepResearchClient",
+        _cli_client_with(
+            (PRIMARY, _params(error_type="billing")),
+            (BACKUP, _params(error_type="auth")),
+        ),
+    )
+    output = tmp_path / "report.md"
+
+    result = CliRunner().invoke(
+        cli_module.app,
+        [
+            "research", "q",
+            "--provider", PRIMARY,
+            "--fallback-provider", BACKUP,
+            "--output", str(output),
+            "--no-cache",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Providers tried:" in result.output
+    assert PRIMARY in result.output and BACKUP in result.output
+    assert not output.exists()
 
 
 def test_cli_rejects_nothing_when_fallback_is_absent(tmp_path, monkeypatch):

--- a/tests/test_provider_fallback.py
+++ b/tests/test_provider_fallback.py
@@ -317,6 +317,38 @@ def test_the_last_failure_propagates_when_everything_fails():
         client.research("q", provider=PRIMARY, fallback=True)
 
 
+def test_exhausting_every_candidate_chains_to_the_failure_before_it():
+    """A caller who catches the last failure can still see there were others.
+
+    Each earlier `except` exits via `continue`, so by the time the last one
+    raises it is no longer being handled and `__context__` is None. Without
+    chaining, a run that tried three providers is indistinguishable to a caller
+    from one that tried the last -- in a feature whose whole point is recording
+    who was tried.
+    """
+    client = _client(
+        (PRIMARY, _params(error_type="billing")),
+        (BACKUP, _params(error_type="auth")),
+        (SPARE, _params(error_type="quota")),
+    )
+    with pytest.raises(ProviderQuotaError) as caught:
+        client.research("q", provider=PRIMARY, fallback=[BACKUP, SPARE])
+
+    # The type and traceback the caller would have had with no fallback at
+    # all are preserved; the cause is what is added.
+    assert isinstance(caught.value.__cause__, ProviderAuthError)
+
+
+def test_a_lone_failure_is_not_given_a_spurious_cause():
+    """Chaining must not invent a predecessor where there was none."""
+    client = _client((PRIMARY, _params(error_type="billing")))
+    with pytest.raises(ProviderBillingError) as caught:
+        client.research("q", provider=PRIMARY)
+
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+
+
 def test_nothing_is_cached_when_every_provider_fails(tmp_path):
     """Fail-closed: no report exists, so no cache entry may either."""
     client = _client(

--- a/tests/test_provider_fallback.py
+++ b/tests/test_provider_fallback.py
@@ -739,40 +739,54 @@ def test_cli_reaches_the_named_fallback_provider(tmp_path, monkeypatch):
     assert not output.exists()
 
 
+def _cli_client_with(*named_params):
+    """Build a substitute for the client the research command constructs.
+
+    The command builds its own client from the environment, and no environment
+    a test can arrange gives it two *available* providers: `mock` is the only
+    one needing no credential, and the rest would make real network calls.
+
+    Nothing is mocked in the `unittest.mock` sense -- the CLI, the client, the
+    providers, the formatter and the file write all run for real; only the
+    wiring between two of them is redirected.
+
+    `provider_configs` is accepted and deliberately not forwarded: passing our
+    own skips environment detection, so whatever this machine happens to have
+    configured cannot join the ordering. Without that, an early version of
+    these tests found the `claude` CLI on PATH and made a real subprocess call.
+
+    Args:
+        named_params: ``(name, MockParams)`` pairs to register, in order.
+
+    Returns:
+        A callable matching the constructor call the research command makes.
+    """
+    real_client_class = cli_module.DeepResearchClient
+
+    def _factory(cache_config=None, provider_configs=None):
+        client = real_client_class(
+            cache_config=cache_config,
+            provider_configs={PRIMARY: ProviderConfig(name=PRIMARY)},
+        )
+        for name, params in named_params:
+            client.registry.register(StandInProvider(ProviderConfig(name=name), params))
+        return client
+
+    return _factory
+
+
 def test_cli_reports_the_trail_on_a_successful_fallback(tmp_path, monkeypatch):
     """The CLI's own fallback output, which no other test reaches.
 
     `test_cli_reaches_the_named_fallback_provider` ends in exit code 1, so the
     `if result.fell_back:` branch never runs there -- deleting it would fail
-    nothing. Reaching it needs two *available* providers, and no environment a
-    test can arrange gives the CLI that: `mock` is the only one without a
-    credential, and the rest would make real network calls.
-
-    So the client the command builds is substituted for one registered with two
-    real providers. Nothing is mocked in the `unittest.mock` sense -- the CLI,
-    the client, both providers, the formatter and the file write all run for
-    real; only the wiring between two of them is redirected.
+    nothing. See `_cli_client_with` for why the client is substituted.
     """
-    real_client_class = cli_module.DeepResearchClient
-
-    def _two_providers(cache_config=None, provider_configs=None):
-        # provider_configs is passed deliberately, not forwarded: it skips
-        # environment detection, so whatever this machine happens to have
-        # configured cannot join the ordering. Without it the fallback found
-        # the `claude` CLI on PATH and made a real subprocess call.
-        client = real_client_class(
-            cache_config=cache_config,
-            provider_configs={PRIMARY: ProviderConfig(name=PRIMARY)},
-        )
-        client.registry.register(
-            StandInProvider(ProviderConfig(name=PRIMARY), _params(error_type="billing"))
-        )
-        client.registry.register(
-            StandInProvider(ProviderConfig(name=BACKUP), _params())
-        )
-        return client
-
-    monkeypatch.setattr(cli_module, "DeepResearchClient", _two_providers)
+    monkeypatch.setattr(
+        cli_module,
+        "DeepResearchClient",
+        _cli_client_with((PRIMARY, _params(error_type="billing")), (BACKUP, _params())),
+    )
     output = tmp_path / "report.md"
 
     result = CliRunner().invoke(
@@ -797,26 +811,6 @@ def test_cli_reports_the_trail_on_a_successful_fallback(tmp_path, monkeypatch):
     content = output.read_text()
     assert "fell_back: true" in content
     assert "simulated billing failure" not in content
-
-
-def _cli_client_with(*named_params):
-    """Build a substitute for the client the research command constructs.
-
-    See `test_cli_reports_the_trail_on_a_successful_fallback` for why the
-    substitution is needed and what it does and does not replace.
-    """
-    real_client_class = cli_module.DeepResearchClient
-
-    def _factory(cache_config=None, provider_configs=None):
-        client = real_client_class(
-            cache_config=cache_config,
-            provider_configs={PRIMARY: ProviderConfig(name=PRIMARY)},
-        )
-        for name, params in named_params:
-            client.registry.register(StandInProvider(ProviderConfig(name=name), params))
-        return client
-
-    return _factory
 
 
 def test_cli_falls_back_when_the_named_provider_is_not_configured(tmp_path, monkeypatch):
@@ -849,6 +843,38 @@ def test_cli_falls_back_when_the_named_provider_is_not_configured(tmp_path, monk
     assert "requested_provider: falcon" in content
     # The provider that could not run is in the trail, not dropped from it.
     assert "ProviderNotConfiguredError" in content
+
+
+def test_cli_still_names_the_available_providers_for_a_typo(tmp_path, monkeypatch):
+    """Standing the pre-check down must not swallow the remedy for a typo.
+
+    A name that is not a provider at all is not "unconfigured", and the fix for
+    it is the list of names that exist -- which lives only in this check. So
+    the stand-down asks the client whether the name is a provider, rather than
+    treating every unavailable name alike.
+    """
+    monkeypatch.setattr(
+        cli_module, "DeepResearchClient", _cli_client_with((BACKUP, _params()))
+    )
+    output = tmp_path / "report.md"
+
+    result = CliRunner().invoke(
+        cli_module.app,
+        [
+            "research", "q",
+            "--provider", "falcn",
+            "--fallback-provider", BACKUP,
+            "--output", str(output),
+            "--no-cache",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "not available" in result.output
+    assert BACKUP in result.output
+    # Never the sentence for a provider that exists but has no credential.
+    assert "not configured" not in result.output
+    assert not output.exists()
 
 
 def test_cli_still_refuses_an_unconfigured_provider_without_a_fallback(tmp_path, monkeypatch):

--- a/tests/test_provider_fallback.py
+++ b/tests/test_provider_fallback.py
@@ -36,6 +36,19 @@ BACKUP = "mock_backup"
 SPARE = "mock_spare"
 
 
+class StandInProvider(MockProvider):
+    """A mock standing in for a provider that does real research.
+
+    MockProvider itself is kept out of the *automatic* fallback ordering,
+    because a run that ran out of credits should fail rather than quietly hand
+    a curation record an invented report. Testing that ordering therefore needs
+    a provider that is not excluded from it -- so this subclass says so, rather
+    than the tests reaching around the rule they are meant to exercise.
+    """
+
+    produces_real_reports = True
+
+
 def _params(**kwargs) -> MockParams:
     """Build mock parameters with no artificial delay."""
     kwargs.setdefault("response_delay", 0.0)
@@ -63,7 +76,7 @@ def _client(*named_params, cache_dir=None) -> DeepResearchClient:
         provider_configs={PRIMARY: ProviderConfig(name=PRIMARY)},
     )
     for name, params in named_params:
-        client.registry.register(MockProvider(ProviderConfig(name=name), params))
+        client.registry.register(StandInProvider(ProviderConfig(name=name), params))
     return client
 
 
@@ -303,6 +316,117 @@ def test_an_unknown_provider_name_is_still_a_plain_error():
 
 
 # --------------------------------------------------------------------------
+# Bad input in the fallback list
+# --------------------------------------------------------------------------
+
+
+def test_a_typo_in_the_fallback_list_fails_before_anything_is_called(caplog):
+    """A name that is not a provider is caught up front, not mid-run.
+
+    Asserting the message alone would prove nothing: the same ValueError
+    surfaces either way, just later. What matters is that no provider was
+    called first -- discovering the typo mid-run would waste that call, never
+    reach the good candidate behind it, and replace the failure that started
+    the fallback with a bare "not found".
+    """
+    client = _client(
+        (PRIMARY, _params(error_type="billing")),
+        (BACKUP, _params()),
+    )
+    with caplog.at_level("WARNING"):
+        with pytest.raises(ValueError, match="'mok_backup' not found"):
+            client.research("q", provider=PRIMARY, fallback=["mok_backup", BACKUP])
+
+    # The primary logs a warning the moment it is called and fails, so silence
+    # here is the evidence that nothing ran.
+    assert [r.getMessage() for r in caplog.records] == []
+
+
+def test_a_typo_is_caught_even_when_the_primary_would_have_succeeded():
+    """Fail fast means fast: the primary is never called either."""
+    client = _client((PRIMARY, _params()))
+    with pytest.raises(ValueError, match="not found"):
+        client.research("q", provider=PRIMARY, fallback=["nonesuch"])
+
+
+def test_every_unknown_name_is_named_at_once():
+    """Fixing one typo only to be told about the next is a poor trade."""
+    client = _client((PRIMARY, _params()))
+    with pytest.raises(ValueError, match="alpha, beta"):
+        client.research("q", provider=PRIMARY, fallback=["alpha", "beta"])
+
+
+def test_a_known_but_unconfigured_name_is_not_treated_as_a_typo():
+    """The distinction the up-front check must preserve.
+
+    ``openai`` is a real provider that simply has no credential here, so it
+    belongs in the trail with its reason -- unlike a name that is not a
+    provider at all.
+    """
+    client = _client(
+        (PRIMARY, _params(error_type="billing")),
+        (BACKUP, _params()),
+    )
+    result = client.research("q", provider=PRIMARY, fallback=["openai", BACKUP])
+    assert result.provider == BACKUP
+    assert [a.provider for a in result.provider_attempts] == [PRIMARY, "openai", BACKUP]
+
+
+def test_a_single_provider_name_is_not_read_as_a_list_of_letters():
+    """``Sequence[str]`` accepts ``str``; ``list("openai")`` is six providers."""
+    client = _client(
+        (PRIMARY, _params(error_type="billing")),
+        (BACKUP, _params()),
+    )
+    result = client.research("q", provider=PRIMARY, fallback=BACKUP)
+    assert result.provider == BACKUP
+    assert [a.provider for a in result.provider_attempts] == [PRIMARY, BACKUP]
+
+
+# --------------------------------------------------------------------------
+# A provider that invents its reports is not a stand-in for one that does not
+# --------------------------------------------------------------------------
+
+
+def test_a_fabricating_provider_is_left_out_of_the_automatic_ordering():
+    """The premise of the feature: a failed run beats an invented report."""
+    client = _client((PRIMARY, _params(error_type="billing")))
+    client.registry.register(MockProvider(ProviderConfig(name=BACKUP), _params()))
+
+    assert BACKUP in [p.name for p in client.registry.get_available_providers()]
+    with pytest.raises(ProviderBillingError):
+        client.research("q", provider=PRIMARY, fallback=True)
+
+
+def test_naming_a_fabricating_provider_still_honours_it():
+    """Asking for it explicitly is a decision, not a stand-in nobody wanted."""
+    client = _client((PRIMARY, _params(error_type="billing")))
+    client.registry.register(MockProvider(ProviderConfig(name=BACKUP), _params()))
+
+    result = client.research("q", provider=PRIMARY, fallback=[BACKUP])
+    assert result.provider == BACKUP
+    assert result.fell_back is True
+
+
+def test_real_providers_declare_themselves_real_by_default():
+    """The exclusion must be opt-in, or it would quietly empty the ordering."""
+    from deep_research_client.providers import ResearchProvider
+
+    assert ResearchProvider.produces_real_reports is True
+    assert MockProvider.produces_real_reports is False
+
+
+def test_a_fabricating_provider_can_still_be_chosen_directly():
+    """Excluding it from fallback must not stop it doing its actual job."""
+    client = DeepResearchClient(
+        cache_config=CacheConfig(enabled=False),
+        provider_configs={PRIMARY: ProviderConfig(name=PRIMARY)},
+    )
+    result = client.research("q", provider=PRIMARY)
+    assert result.provider == PRIMARY
+
+
+# --------------------------------------------------------------------------
 # Caching must not inherit another run's provenance
 # --------------------------------------------------------------------------
 
@@ -394,6 +518,32 @@ def test_dropping_overrides_is_said_out_loud(caplog):
     messages = [record.getMessage() for record in caplog.records]
     assert any("own defaults" in message for message in messages)
     assert any("--param" in message for message in messages)
+
+
+def test_the_dropped_override_warning_names_the_provider_that_got_them(caplog):
+    """Past the first hop, the provider that just failed had no overrides either.
+
+    Naming it would assert that parameters were applied to a provider which in
+    fact ran on its own defaults -- in a message whose whole job is provenance.
+    """
+    client = _client(
+        (PRIMARY, _params(error_type="billing")),
+        (BACKUP, _params(error_type="auth")),
+        (SPARE, _params()),
+    )
+    with caplog.at_level("WARNING"):
+        client.research(
+            "q",
+            provider=PRIMARY,
+            provider_params={"error_type": "billing", "response_delay": 0.0},
+            fallback=[BACKUP, SPARE],
+        )
+
+    dropped = [m for m in (r.getMessage() for r in caplog.records) if "own defaults" in m]
+    assert len(dropped) == 2
+    # Both hops must credit the primary, the only candidate that got them.
+    assert all(f"applied to {PRIMARY}" in message for message in dropped)
+    assert not any(f"applied to {BACKUP}" in message for message in dropped)
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Closes #69. The runtime half of [monarch-initiative/dismech#8512](https://github.com/monarch-initiative/dismech/issues/8512); #66 was the diagnostic half.

#66 made a failed run explain itself. It did not act on the explanation: `research()` called one provider once, and a `ProviderBillingError` propagated to the caller. This adds the acting, with the constraint that made it worth leaving out of #66 in the first place.

## The constraint, first

**A silent fallback would falsify dismech's curation history.** Those records name the provider that produced a report. So this is not "retry elsewhere on failure" — it is that plus provenance, and the provenance is the part that took the design work.

- **Opt-in, never default.** `fallback=False` is the default and runs the identical code path as before.
- **The report says who produced it, who was asked, and who was tried.**
- **Only failures where another provider could help are followed.**
- **Fail-closed.** Nothing is cached, written or returned until a provider succeeds.

## Interface

```bash
deep-research-client research "Statins and myopathy" --provider falcon --fallback

# Or name the order yourself; this replaces the automatic ordering rather than extending it
deep-research-client research "CRISPR delivery" \
  --provider falcon --fallback-provider openai --fallback-provider perplexity
```

```python
result = client.research("Statins and myopathy", provider="falcon", fallback=True)
result.provider            # who actually produced it
result.requested_provider  # who was asked
result.fell_back           # whether a switch happened
result.provider_attempts   # each provider tried, and why it failed
```

`fallback` takes `False` (default), `True`, an ordered list, or a bare name for one.

When every candidate fails, the run still explains itself: the trail is attached to the raised `ProviderError` as `provider_attempts`, and the CLI prints it. A provider that bare-raises what it cannot classify has no such field, so read it as `getattr(err, "provider_attempts", ())` — in that case the client logs the trail rather than losing it.

## What lands in the report

```yaml
provider: openai
fell_back: true
requested_provider: falcon
provider_attempts:
- provider: falcon
  succeeded: false
  error_type: ProviderBillingError
  status_code: 402
  remedy: the account is out of credits
  retryable: false
- provider: openai
  succeeded: true
```

A report that came from the provider it was asked of gains **none** of these keys — their presence is the finding, and every existing report renders byte-identical. The CLI also warns rather than informs when a switch happens.

## Judgement calls worth reviewing

**`is_fallback_worthy` is its own predicate, not `not retryable`.** These answer different questions — "would calling someone else help?" versus "would calling this one again help?" — and they look complementary only by coincidence of today's types. An error meaning "the request itself is malformed" would answer no to both.

| Failure | Falls back? | Why |
|---|---|---|
| 402, spent quota, 401/403, not configured | Yes | This provider cannot do the work |
| 429 | No | The same provider will take it shortly |
| 5xx | No | A temporary fault, not a reason to change who answers |
| Anything unrecognised | No | Not evidence another provider would do better |

That last row is the conservative default. A fallback changes who produced your report, so a bare `ValueError` whose cause nobody established does not justify one. It also means an unclassified failure ends the run *wherever it happens*, with candidates behind it left untried — so the diagnostic names the candidate that ended the run rather than claiming every one failed.

**The report carries our words, never the provider's.** `provider_attempts` entries render `error_type`, `status_code`, `remedy` and `retryable` — every one produced by us. The provider's own error text is deliberately withheld, because for a 401 that text is the thing most likely to quote the credential just rejected, and these reports get committed. It stays on `result.provider_attempts[*].reason` and in the logs, which is where an operator diagnosing an outage is looking anyway.

The rule is checkable by reading the list of keys rather than tracing each value's origin, and that is the point of it — so a quota error's reset time is withheld too, despite being harmless in itself, since it is parsed out of provider text and keeping it would make the rule "ours, except one field".

**A provider that invents its reports is not a stand-in for one that doesn't.** `mock` is excluded from `--fallback`'s automatic ordering via `ResearchProvider.produces_real_reports`, so a run that spends its credits fails rather than quietly handing a curation record a fabricated report. `--fallback-provider mock` still honours it — that is a decision, not a stand-in nobody asked for.

**`--model` and `--param` apply to the first candidate only.** They were chosen for the provider the caller named. A Perplexity model name means nothing to OpenAI, and an unknown parameter is a hard schema error — so without this, `--provider perplexity --param reasoning_effort=high --fallback` would have died on the *fallback provider's schema* rather than on the outage. Fallback providers run on their own defaults and the run says so, because silently dropping what was asked for is the other bad answer.

**Provenance is stamped after the cache write, never before,** and from inside `_record_provenance` rather than at each return — so no path can return a result without saying who produced it. These fields describe one run; replaying them out of a cache file would credit a later run with a fallback that never happened.

**The last candidate re-raises bare.** Not a new "everything failed" exception type, which would stop a caller catching `ProviderBillingError` from seeing it. The failure keeps the type and traceback it would have had with no fallback at all — including the `__cause__` the provider set to its own SDK error, which is why the trail gets its own field rather than taking that one.

**Where the provenance lives.** #69 suggests doing this with #50 rather than building a second mechanism beside it. These are first-class `ResearchResult` fields, which is the shape #50 proposes — so `provider_job_id` / `provider_job_url` slot in beside them. I did **not** implement #50; capturing upstream job IDs per provider is separate work.

## The mock provider gained a real capability

Exercising this needed a provider that fails on demand with a typed error. Writing one in the test file would have made it scaffolding, so it went on the shipped mock instead, where anyone can see the behaviour before relying on it:

```bash
ENABLE_MOCK_PROVIDER=true deep-research-client research "test" \
  --provider mock --param error_type=quota --fallback --output report.md
```

`error_type=quota` is the one worth running: it is the only failure whose remedy embeds provider-supplied text, so the console prints `renews at 3pm, pool quota_pool_7f21` while the saved report keeps only `the plan's usage limit is spent`. The literals map to the real exception classes and a test compares the mock's shape against the real classifier's, so the two cannot drift.

## Defects I shipped and caught

**Two `ResultFormatter` classes.** The CLI writes reports through `processing/result_formatter.py`, while the top-level `formatter.py` stays importable. I patched only the second, so a CLI-written report would not have recorded the fallback at all. Found it re-reading my own diff; the rendering moved onto `ResearchResult` so there is one implementation, and the formatter tests are parametrized over both.

**A commit message that asserted something untrue.** A later commit claimed two doc corrections landed in both the README and the how-to. The script aborted on a failed match before writing the second, and I checked the test suite rather than the file. Both are correct now, and each edit was verified against the file afterwards.

**Chaining the trail onto `__cause__`.** An earlier version raised the terminal failure `from` the previous one, which overwrote the `__cause__` that `openai.py`, `falcon.py` and `consensus.py` deliberately set to the upstream SDK error. A regression against pre-branch behaviour, invisible to a suite whose every failure came from a mock that raises bare. The trail moved to its own field, and a test now builds a provider that chains its own cause.

**A diagnostic that overstated.** The "every provider failed" log fired even when an unclassified failure ended the run early, leaving candidates untried. Its test could not see it, because the unclassifiable provider was last — the one arrangement where the wording was true.

## Testing

**898 tests + 159 doctests, mypy and ruff clean, `mkdocs build --strict` clean.** 78 new tests, no mocks of the code under test: the failures come from the shipped mock provider raising the same typed errors a real provider raises, so the client runs its ordinary path — registry, cache, provenance, formatter and CLI included.

Each guard below was checked by deleting it and re-running the suite. Counts re-measured on the current head:

| Guard removed | Tests that fail |
|---|---|
| Live formatter's fallback block | 7 |
| Withhold the provider's error text from the report | 6 |
| Fall back on any failure | 5 |
| Hand the caller's overrides to every candidate | 4 |
| Validate fallback names up front | 3 |
| Stamp provenance before the cache write | 2 |
| Exclude the fabricating provider from automatic ordering | 1 |
| Announce a fallback on the cache-hit path | 1 |
| Keep the typo/unconfigured distinction in the CLI | 1 |
| Match the mock's quota shape to a real one | 1 |
| Name the candidate that ended the run, not the whole list | 1 |

One CLI test substitutes the client the command builds, because no environment a test can arrange gives the CLI two *available* providers. Nothing is mocked in the `unittest.mock` sense — CLI, client, providers, formatter and file write all run for real; only the wiring between two of them is redirected. An early version of it found the `claude` CLI on PATH and made a real subprocess call, so it now skips environment detection outright.

## Review history

Fifteen automated passes, no merge blocker at any point. Worth knowing which findings were real rather than tidy-ups — a typo in `--fallback-provider` killing a run *after* the primary had been paid for; the provider's raw error text landing in committed files; `fallback="openai"` silently becoming six one-letter providers; the CLI refusing a fallback its own docs promised; the `__cause__` displacement and the overstated diagnostic above. Several rounds found defects in the previous round's fixes, and those are recorded in the commit messages rather than tidied away.

The later passes converged on refinements rather than defects. Three findings from the final pass are deliberately left for follow-up work: extracting the three trail-rendering call sites into one helper, a negative assertion pinning the CLI's empty-trail guard, and a note at one call site. None of them changes behaviour.

## Note on the release

v0.2.11 is on hold pending this. It will also carry the **linkml 1.9.6 → 1.11.1** bump from #74, which is unrelated to this PR but rides in the same release.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CUcMgfCdBzEX4PLqFguEmE