### PR TITLE
Say when a fallback had nowhere to go, and stop describing the run as all-or-nothing

### DIFF
--- a/docs/how-to/choose-provider.md
+++ b/docs/how-to/choose-provider.md
@@ -238,6 +238,14 @@ Two other places behave differently, and it is worth being precise about how:
 The last row is the conservative default: a fallback changes who produced your
 report, so it is taken only where the failure type is evidence it should be.
 
+**A "No" ends the run; it does not skip to the next candidate.** This is the
+part that surprises people. If you write `--fallback-provider a
+--fallback-provider b` and `a` returns a 429, the run stops there and `b` is
+never called — the same failure that does not justify switching also does not
+justify carrying on. So the trail lists what was tried, which on such a run is
+a prefix of what you named, and the log says the run ended rather than that
+everything failed.
+
 \* Unless that provider has already answered this query, in which case its own
 cached report is served and nothing falls back — see *A provider you can no
 longer reach* below.
@@ -249,10 +257,12 @@ for the provider you named -- a Perplexity model name means nothing to OpenAI,
 and an unknown parameter is a hard error. A fallback provider therefore runs on
 its own defaults, and the run says so on stderr when it happens.
 
-**Nothing is written until a provider succeeds.** If every candidate fails, the
-run raises with the last failure and no report, no cache entry, and no partial
-file is left behind. Since there is no result, there is no
-`provider_attempts` on one — so the trail is carried on the error instead.
+**Nothing is written until a provider succeeds.** When the run ends on a
+failure it cannot follow — the last candidate failing, or an earlier one
+failing in a way that does not justify a switch — it raises with that failure
+and no report, no cache entry, and no partial file is left behind. Since there
+is no result, there is no `provider_attempts` on one — so the trail is carried
+on the error instead.
 Read it with `getattr(err, "provider_attempts", ())`: it lists every candidate
 tried, including the one whose failure ended the run, but only when that
 failure is one the client classified. A provider that cannot recognise its own
@@ -260,8 +270,8 @@ SDK error re-raises it bare, and a plain exception has no field to carry a
 trail; the run logs it in that case instead. `err.__cause__` is left alone
 either way, because providers set it themselves to the upstream API error.
 
-The CLI prints the same trail on a run where every candidate failed, so you do
-not need to catch anything to see it.
+The CLI prints the same trail on any run that ends this way, so you do not need
+to catch anything to see it.
 
 **A provider you can no longer reach can still answer from its own cache.**
 When a candidate cannot be prepared — its key revoked, say — and *another

--- a/docs/how-to/choose-provider.md
+++ b/docs/how-to/choose-provider.md
@@ -320,7 +320,23 @@ ENABLE_MOCK_PROVIDER=true deep-research-client research "test" \
 
 If you have no other provider configured, the run has nowhere to go and stops
 with the mock's simulated billing failure -- which is the fail-closed behaviour,
-not a bug. To watch the switch happen without configuring anything, name
+not a bug. The run will say so itself if you ask it to -- `-v` is a global
+option, so it goes before the subcommand:
+
+```bash
+ENABLE_MOCK_PROVIDER=true deep-research-client -v research "test" \
+  --provider mock --param error_type=billing --fallback
+```
+
+```
+INFO  Fallback was requested, but mock is the only candidate: no other
+      provider is available. The run will behave as though no fallback was
+      asked for
+```
+
+That line is `INFO` rather than a warning because it also fires on runs that
+succeed, where a warning would be noise -- so it is there when you go looking
+and quiet when you are not. To watch the switch happen without configuring anything, name
 `deeper_med` as the fallback: it is a permanently unavailable stub, so the run
 still ends in an error and writes no report, but the log shows the fallback
 being taken and each provider explaining itself:

--- a/docs/how-to/choose-provider.md
+++ b/docs/how-to/choose-provider.md
@@ -329,14 +329,14 @@ ENABLE_MOCK_PROVIDER=true deep-research-client -v research "test" \
 ```
 
 ```
-INFO  Fallback was requested, but mock is the only candidate: no other
-      provider is available. The run will behave as though no fallback was
-      asked for
+INFO - Fallback was requested, but mock is the only candidate: no other provider is available. The run will behave as though no fallback was asked for
 ```
 
 That line is `INFO` rather than a warning because it also fires on runs that
 succeed, where a warning would be noise -- so it is there when you go looking
-and quiet when you are not. To watch the switch happen without configuring anything, name
+and quiet when you are not.
+
+To watch the switch happen without configuring anything, name
 `deeper_med` as the fallback: it is a permanently unavailable stub, so the run
 still ends in an error and writes no report, but the log shows the fallback
 being taken and each provider explaining itself:

--- a/src/deep_research_client/cli.py
+++ b/src/deep_research_client/cli.py
@@ -1007,7 +1007,7 @@ def research(
         # console-versus-report split that used to be argued here.
         if result.fell_back:
             logger.warning(
-                "Providers tried:\n  %s",
+                "Providers tried:\n%s",
                 ProviderAttempt.render_trail(result.provider_attempts),
             )
 
@@ -1079,7 +1079,7 @@ def research(
             # cost -- unlike the success path, where the duplicated sentence
             # carried nothing the trail did not.
             logger.error(
-                "Providers tried:\n  %s",
+                "Providers tried:\n%s",
                 ProviderAttempt.render_trail(attempts),
             )
         raise typer.Exit(1)

--- a/src/deep_research_client/cli.py
+++ b/src/deep_research_client/cli.py
@@ -32,7 +32,7 @@ from .model_cards import (
     TimeEstimate,
     ModelCapability
 )
-from .models import ProviderHealth, ResearchResult, sanitize_artifact_filename
+from .models import ProviderAttempt, ProviderHealth, ResearchResult, sanitize_artifact_filename
 
 # Configure logging
 logger = logging.getLogger("deep_research_client")
@@ -1003,19 +1003,12 @@ def research(
 
         # The client already warned that someone else produced this. Restating
         # it here made one fallback emit the same sentence twice; what the CLI
-        # adds is the trail, so that is all it prints.
-        #
-        # summary() carries the provider's own error text, which the *report*
-        # deliberately withholds. That difference is intended and was weighed:
-        # the console is where an operator diagnoses a failed provider, and
-        # withholding it there costs them the evidence while protecting
-        # nothing the raised error did not already print. A committed file is
-        # read by people who were not running the command, which is the
-        # distinction -- not secrecy.
+        # adds is the trail, so that is all it prints. render_trail owns the
+        # console-versus-report split that used to be argued here.
         if result.fell_back:
             logger.warning(
                 "Providers tried:\n  %s",
-                "\n  ".join(attempt.summary() for attempt in result.provider_attempts),
+                ProviderAttempt.render_trail(result.provider_attempts),
             )
 
         # Determine if we're separating citations
@@ -1067,16 +1060,27 @@ def research(
 
     except ValueError as exc:
         logger.error(f"Error: {exc}")
-        # The trail is on the error when every candidate failed. Without this
-        # the CLI says more about who was tried when a fallback *worked* than
-        # when it did not, which is backwards: the total failure is where an
-        # operator needs it. getattr, because an unclassified failure carries
-        # no such attribute -- the client logs the trail itself in that case.
+        # The trail is on the error whenever the run ended on a failure it
+        # could not follow -- which is not only the last candidate, since a
+        # 429 or an unclassified error ends the run wherever it lands. Without
+        # this the CLI would say more about who was tried when a fallback
+        # *worked* than when it did not, which is backwards: the failed run is
+        # where an operator needs it. getattr, because an unclassified failure
+        # carries no such attribute -- the client logs the trail in that case.
+        #
+        # The guard matters: an ordinary single-provider failure carries an
+        # empty trail, and a bare "Providers tried:" header under it would be
+        # noise. Deleting it is a visible regression, so a test pins it.
         attempts = getattr(exc, "provider_attempts", ())
         if attempts:
+            # The last entry restates the error line above, minus its `Try:`
+            # suffix. Dropping it would make the list stop short of the
+            # failure that ended the run, so the repetition is the lesser
+            # cost -- unlike the success path, where the duplicated sentence
+            # carried nothing the trail did not.
             logger.error(
                 "Providers tried:\n  %s",
-                "\n  ".join(attempt.summary() for attempt in attempts),
+                ProviderAttempt.render_trail(attempts),
             )
         raise typer.Exit(1)
     except OSError as exc:

--- a/src/deep_research_client/client.py
+++ b/src/deep_research_client/client.py
@@ -418,6 +418,33 @@ class DeepResearchClient:
 
         if not ordered:
             raise ValueError("No research providers available")
+
+        # A fallback was asked for and there is nobody to fall back to. The
+        # run is about to behave exactly as it would with no flag at all, and
+        # without this nothing distinguishes that from "the fallback ran and
+        # also failed" -- the trail is empty either way at position 0.
+        #
+        # Both routes are easy to hit: the automatic ordering drops providers
+        # that do not produce real reports, and a named fallback that repeats
+        # the primary deduplicates away. The reason is the invisible part, so
+        # say which one it was.
+        if fallback and len(ordered) == 1:
+            excluded = [
+                candidate.name
+                for candidate in self.registry.get_available_providers()
+                if not candidate.produces_real_reports and candidate.name != ordered[0]
+            ]
+            logger.info(
+                "Fallback was requested, but %s is the only candidate: %s. "
+                "The run will behave as though no fallback was asked for",
+                ordered[0],
+                (
+                    "the other available provider(s) do not produce real "
+                    f"reports ({', '.join(excluded)})"
+                    if excluded
+                    else "no other provider was named or available"
+                ),
+            )
         return ordered
 
     def _prepare_provider(
@@ -533,10 +560,11 @@ class DeepResearchClient:
             return
         logger.warning(
             "Provider %s failed with %s, which cannot carry the trail. "
+            "The run ends here; any candidate after it was not tried. "
             "Providers tried:\n  %s",
             candidate,
             type(exc).__name__,
-            "\n  ".join(attempt.summary() for attempt in trail),
+            ProviderAttempt.render_trail(trail),
         )
 
     @staticmethod

--- a/src/deep_research_client/client.py
+++ b/src/deep_research_client/client.py
@@ -452,16 +452,24 @@ class DeepResearchClient:
                 if fallback is True
                 else []
             )
+            # Three reasons, not two. "named or available" as one string
+            # asserts on the list route that nobody else is here, when the
+            # truth is usually that nobody else was listed -- and listing one
+            # is the fix the operator needs pointing at.
+            if excluded:
+                reason = (
+                    "the other available provider(s) do not produce real "
+                    f"reports ({', '.join(excluded)})"
+                )
+            elif fallback is True:
+                reason = "no other provider is available"
+            else:
+                reason = "no other provider was named"
             logger.info(
                 "Fallback was requested, but %s is the only candidate: %s. "
                 "The run will behave as though no fallback was asked for",
                 ordered[0],
-                (
-                    "the other available provider(s) do not produce real "
-                    f"reports ({', '.join(excluded)})"
-                    if excluded
-                    else "no other provider was named or available"
-                ),
+                reason,
             )
         return ordered
 

--- a/src/deep_research_client/client.py
+++ b/src/deep_research_client/client.py
@@ -360,6 +360,11 @@ class DeepResearchClient:
                 whatever else is available, or an ordered list of provider
                 names. A single name may be given as a bare string.
 
+        Logs at INFO when a fallback was requested but only one candidate
+        survives, since the run is then about to behave as though no fallback
+        had been asked for. Planning and saying so live together because the
+        reason -- which filter or which absent name -- is known only here.
+
         Returns:
             Provider names to try, most-preferred first, without duplicates.
             With True, the automatic ones follow registration order.
@@ -429,11 +434,24 @@ class DeepResearchClient:
         # the primary deduplicates away. The reason is the invisible part, so
         # say which one it was.
         if fallback and len(ordered) == 1:
-            excluded = [
-                candidate.name
-                for candidate in self.registry.get_available_providers()
-                if not candidate.produces_real_reports and candidate.name != ordered[0]
-            ]
+            # `is True`, not truthiness: a list is truthy too, and the
+            # produces_real_reports filter above runs only on the automatic
+            # route. An explicitly named provider that invents its reports is
+            # honoured, so on the list route a mock sitting in the registry
+            # was not excluded for fabricating -- it simply was not named.
+            # Blaming the filter there would tell an operator their own
+            # --fallback-provider mock would be dropped, which is the reverse
+            # of what happens.
+            excluded = (
+                [
+                    candidate.name
+                    for candidate in self.registry.get_available_providers()
+                    if not candidate.produces_real_reports
+                    and candidate.name != ordered[0]
+                ]
+                if fallback is True
+                else []
+            )
             logger.info(
                 "Fallback was requested, but %s is the only candidate: %s. "
                 "The run will behave as though no fallback was asked for",
@@ -561,7 +579,7 @@ class DeepResearchClient:
         logger.warning(
             "Provider %s failed with %s, which cannot carry the trail. "
             "The run ends here; any candidate after it was not tried. "
-            "Providers tried:\n  %s",
+            "Providers tried:\n%s",
             candidate,
             type(exc).__name__,
             ProviderAttempt.render_trail(trail),
@@ -667,8 +685,9 @@ class DeepResearchClient:
         those propagate as they always did.
 
         Nothing is cached or returned until a provider actually succeeds, so a
-        run that exhausts every candidate raises rather than producing a
-        partial result.
+        run that ends without one raises rather than producing a partial
+        result -- whether it exhausted the candidates or stopped at a failure
+        that did not justify trying the next.
         """
         start_time = datetime.now()
         start_timestamp = time.time()

--- a/src/deep_research_client/models.py
+++ b/src/deep_research_client/models.py
@@ -1,6 +1,6 @@
 """Pydantic models for deep research client."""
 
-from typing import List, Optional, Dict, Any
+from typing import List, Optional, Dict, Any, Sequence
 from datetime import datetime
 import re
 
@@ -231,6 +231,38 @@ class ProviderAttempt(BaseModel):
         if self.succeeded:
             return f"{self.provider}: produced the report"
         return f"{self.provider}: {self.reason or self.error_type or 'failed'}"
+
+    @staticmethod
+    def render_trail(attempts: "Sequence[ProviderAttempt]") -> str:
+        """Render a run's attempts as the indented block three callers print.
+
+        The CLI prints this on a successful fallback and again when every
+        candidate failed, and the client logs it when the terminal failure
+        cannot carry the trail. An operator meets those on different days and
+        should recognise the second from the first, so the indent and the
+        choice of ``summary()`` belong here rather than in three call sites
+        that have to stay in step.
+
+        ``summary()`` carries the provider's own error text, which
+        :meth:`frontmatter_entry` withholds. That split is deliberate: this
+        renders to a console or a log, read by whoever ran the command, and
+        never to a file that gets committed.
+
+        Args:
+            attempts: The attempts to render, in the order they were tried.
+
+        Returns:
+            One line per attempt, each indented two spaces after the first.
+
+        >>> from .exceptions import ProviderBillingError
+        >>> spent = ProviderAttempt.from_exception(
+        ...     "falcon", ProviderBillingError("falcon", "no credits", 402))
+        >>> print(ProviderAttempt.render_trail(
+        ...     [spent, ProviderAttempt(provider="openai", succeeded=True)]))
+        falcon: 402 no credits -- the account is out of credits
+          openai: produced the report
+        """
+        return "\n  ".join(attempt.summary() for attempt in attempts)
 
 
 class ResearchResult(BaseModel):

--- a/src/deep_research_client/models.py
+++ b/src/deep_research_client/models.py
@@ -268,6 +268,13 @@ class ProviderAttempt(BaseModel):
         ...     [spent, ProviderAttempt(provider="openai", succeeded=True)]))
           falcon: 402 no credits -- the account is out of credits
           openai: produced the report
+
+        Nothing in, nothing out -- pinned here because every caller guards
+        against an empty sequence, so this is unreachable from the outside
+        and a leading-concat rewrite would otherwise pass the whole suite:
+
+        >>> ProviderAttempt.render_trail([])
+        ''
         """
         # Per-line rather than a leading concat: identical for every non-empty
         # input, and "" rather than a lone indent for the empty one -- so a

--- a/src/deep_research_client/models.py
+++ b/src/deep_research_client/models.py
@@ -268,7 +268,11 @@ class ProviderAttempt(BaseModel):
           falcon: 402 no credits -- the account is out of credits
           openai: produced the report
         """
-        return "  " + "\n  ".join(attempt.summary() for attempt in attempts)
+        # Per-line rather than a leading concat: identical for every non-empty
+        # input, and "" rather than a lone indent for the empty one -- so a
+        # caller trusting "ready to sit under a bare header" gets nothing
+        # under the header rather than a whitespace line.
+        return "\n".join(f"  {attempt.summary()}" for attempt in attempts)
 
 
 class ResearchResult(BaseModel):

--- a/src/deep_research_client/models.py
+++ b/src/deep_research_client/models.py
@@ -256,7 +256,8 @@ class ProviderAttempt(BaseModel):
             The leading indent is part of it, so a caller need only put the
             header and a newline in front; owning half the format here and
             half at three call sites is what let them drift in the first
-            place.
+            place. Empty in, empty out -- never a lone indent, so a header
+            with nothing to say has nothing under it.
 
         >>> from .exceptions import ProviderBillingError
         >>> spent = ProviderAttempt.from_exception(

--- a/src/deep_research_client/models.py
+++ b/src/deep_research_client/models.py
@@ -236,11 +236,11 @@ class ProviderAttempt(BaseModel):
     def render_trail(attempts: "Sequence[ProviderAttempt]") -> str:
         """Render a run's attempts as the indented block three callers print.
 
-        The CLI prints this on a successful fallback and again when every
-        candidate failed, and the client logs it when the terminal failure
+        The CLI prints this on a successful fallback and again on a run that
+        ended without one, and the client logs it when the terminal failure
         cannot carry the trail. An operator meets those on different days and
-        should recognise the second from the first, so the indent and the
-        choice of ``summary()`` belong here rather than in three call sites
+        should recognise the second from the first, so the whole format --
+        the indent included -- belongs here rather than in three call sites
         that have to stay in step.
 
         ``summary()`` carries the provider's own error text, which
@@ -252,17 +252,23 @@ class ProviderAttempt(BaseModel):
             attempts: The attempts to render, in the order they were tried.
 
         Returns:
-            One line per attempt, each indented two spaces after the first.
+            One indented line per attempt, ready to sit under a bare header.
+            The leading indent is part of it, so a caller need only put the
+            header and a newline in front; owning half the format here and
+            half at three call sites is what let them drift in the first
+            place.
 
         >>> from .exceptions import ProviderBillingError
         >>> spent = ProviderAttempt.from_exception(
         ...     "falcon", ProviderBillingError("falcon", "no credits", 402))
+        >>> print("Providers tried:")
+        Providers tried:
         >>> print(ProviderAttempt.render_trail(
         ...     [spent, ProviderAttempt(provider="openai", succeeded=True)]))
-        falcon: 402 no credits -- the account is out of credits
+          falcon: 402 no credits -- the account is out of credits
           openai: produced the report
         """
-        return "\n  ".join(attempt.summary() for attempt in attempts)
+        return "  " + "\n  ".join(attempt.summary() for attempt in attempts)
 
 
 class ResearchResult(BaseModel):

--- a/tests/test_provider_fallback.py
+++ b/tests/test_provider_fallback.py
@@ -65,6 +65,13 @@ class UnclassifiableFailure(StandInProvider):
         raise RuntimeError("connection reset by peer")
 
 
+# Named explicitly wherever an INFO record is asserted on: caplog.at_level with
+# no logger raises the *root* level, and a CLI test elsewhere in this suite
+# leaves this one pinned at WARNING -- so an INFO record is dropped before any
+# handler sees it. The tests pass run alone and fail in the full suite.
+_CLIENT_LOGGER = "deep_research_client.client"
+
+
 def _params(**kwargs) -> MockParams:
     """Build mock parameters with no artificial delay."""
     kwargs.setdefault("response_delay", 0.0)
@@ -447,10 +454,7 @@ def test_a_requested_fallback_with_nobody_to_switch_to_says_so(caplog):
     # precisely because it does not produce real reports.
     client.registry.register(MockProvider(ProviderConfig(name=BACKUP), _params()))
 
-    # Named explicitly: at_level with no logger raises the *root* level, and a
-    # CLI test elsewhere in the suite leaves this logger pinned at WARNING, so
-    # an INFO record would be dropped before any handler saw it.
-    with caplog.at_level("INFO", logger="deep_research_client.client"):
+    with caplog.at_level("INFO", logger=_CLIENT_LOGGER):
         with pytest.raises(ProviderBillingError):
             client.research("q", provider=PRIMARY, fallback=True)
 
@@ -464,10 +468,7 @@ def test_a_named_fallback_that_repeats_the_primary_says_so(caplog):
     """The other route to one candidate: the name deduplicates away."""
     client = _client((PRIMARY, _params(error_type="billing")), (BACKUP, _params()))
 
-    # Named explicitly: at_level with no logger raises the *root* level, and a
-    # CLI test elsewhere in the suite leaves this logger pinned at WARNING, so
-    # an INFO record would be dropped before any handler saw it.
-    with caplog.at_level("INFO", logger="deep_research_client.client"):
+    with caplog.at_level("INFO", logger=_CLIENT_LOGGER):
         with pytest.raises(ProviderBillingError):
             client.research("q", provider=PRIMARY, fallback=[PRIMARY])
 
@@ -476,14 +477,37 @@ def test_a_named_fallback_that_repeats_the_primary_says_so(caplog):
     assert "no other provider was named or available" in said[0]
 
 
+def test_the_reason_given_is_the_reason_that_applied(caplog):
+    """Naming a cause that is not the cause is the bug this PR is about.
+
+    The `produces_real_reports` filter runs only on the automatic route. An
+    explicitly named provider that invents its reports is honoured -- so when
+    a list route dedups to one candidate while a mock happens to sit in the
+    registry, that mock was not excluded for fabricating. It simply was not
+    named. Blaming the filter would tell an operator that their own
+    `--fallback-provider mock_backup` would be dropped, which is the reverse
+    of what happens.
+    """
+    client = _client((PRIMARY, _params(error_type="billing")))
+    # Available, and not a real-report provider -- the bait for the wrong reason.
+    client.registry.register(MockProvider(ProviderConfig(name=BACKUP), _params()))
+
+    with caplog.at_level("INFO", logger=_CLIENT_LOGGER):
+        with pytest.raises(ProviderBillingError):
+            client.research("q", provider=PRIMARY, fallback=[PRIMARY])
+
+    said = [r.getMessage() for r in caplog.records if "only candidate" in r.getMessage()]
+    assert len(said) == 1
+    assert "no other provider was named or available" in said[0]
+    assert "do not produce real reports" not in said[0]
+    assert BACKUP not in said[0]
+
+
 def test_a_real_fallback_does_not_claim_it_had_nobody(caplog):
     """The diagnostic must not fire on the runs it is not about."""
     client = _client((PRIMARY, _params(error_type="billing")), (BACKUP, _params()))
 
-    # Named explicitly: at_level with no logger raises the *root* level, and a
-    # CLI test elsewhere in the suite leaves this logger pinned at WARNING, so
-    # an INFO record would be dropped before any handler saw it.
-    with caplog.at_level("INFO", logger="deep_research_client.client"):
+    with caplog.at_level("INFO", logger=_CLIENT_LOGGER):
         result = client.research("q", provider=PRIMARY, fallback=[BACKUP])
 
     assert result.provider == BACKUP

--- a/tests/test_provider_fallback.py
+++ b/tests/test_provider_fallback.py
@@ -1296,6 +1296,42 @@ def test_cli_falls_back_when_the_named_provider_is_not_configured(tmp_path, monk
     assert "ProviderNotConfiguredError" in content
 
 
+def test_cli_v_surfaces_the_inert_fallback_diagnostic(tmp_path, monkeypatch):
+    """The docs promise `-v` shows it, so pin that the wiring delivers.
+
+    The message is INFO and the CLI defaults to WARNING, so by default an
+    operator sees nothing -- deliberately, since it also fires on runs that
+    succeed. That makes `-v` the whole of its reachability from the command
+    line, and `-v` is a *global* option: it goes before the subcommand.
+    """
+    monkeypatch.setattr(
+        cli_module,
+        "DeepResearchClient",
+        _cli_client_with((PRIMARY, _params(error_type="billing"))),
+    )
+    output = tmp_path / "report.md"
+
+    # Asserted on the captured output, not caplog: the CLI's setup_logging
+    # calls basicConfig(force=True), which closes caplog's handler, so records
+    # emitted inside the invocation never reach it. This is the handler half
+    # of the leak that _restore_package_log_level deliberately does not cover.
+    result = CliRunner().invoke(
+        cli_module.app,
+        [
+            "-v",
+            "research", "q",
+            "--provider", PRIMARY,
+            "--fallback",
+            "--output", str(output),
+            "--no-cache",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "candidate: no other provider is available." in result.output
+    assert not output.exists()
+
+
 def test_cli_prints_no_trail_header_when_there_is_no_trail(tmp_path, monkeypatch):
     """An ordinary single-provider failure must not grow a bare header.
 

--- a/tests/test_provider_fallback.py
+++ b/tests/test_provider_fallback.py
@@ -54,6 +54,17 @@ class StandInProvider(MockProvider):
     produces_real_reports = True
 
 
+class UnclassifiableFailure(StandInProvider):
+    """A provider whose SDK error nothing recognises.
+
+    `openai.py` re-raises bare what `_classify_openai_error` cannot place, so
+    an exception with no `provider_attempts` field really does reach the loop.
+    """
+
+    async def research(self, query):
+        raise RuntimeError("connection reset by peer")
+
+
 def _params(**kwargs) -> MockParams:
     """Build mock parameters with no artificial delay."""
     kwargs.setdefault("response_delay", 0.0)
@@ -384,12 +395,6 @@ def test_an_unclassified_terminal_failure_logs_the_trail_instead(caplog):
     of losing it.
     """
 
-    class UnclassifiableFailure(StandInProvider):
-        """A provider whose SDK error nothing recognises."""
-
-        async def research(self, query):
-            raise RuntimeError("connection reset by peer")
-
     client = _client((PRIMARY, _params(error_type="billing")))
     client.registry.register(UnclassifiableFailure(ProviderConfig(name=BACKUP), _params()))
 
@@ -413,12 +418,6 @@ def test_an_unclassified_failure_before_the_last_candidate_names_itself(caplog):
     when the last one was never reached.
     """
 
-    class UnclassifiableFailure(StandInProvider):
-        """A provider whose SDK error nothing recognises."""
-
-        async def research(self, query):
-            raise RuntimeError("connection reset by peer")
-
     client = _client((PRIMARY, _params(error_type="billing")), (SPARE, _params()))
     client.registry.register(UnclassifiableFailure(ProviderConfig(name=BACKUP), _params()))
 
@@ -432,6 +431,84 @@ def test_an_unclassified_failure_before_the_last_candidate_names_itself(caplog):
     assert f"Provider {BACKUP} failed with RuntimeError" in trail[0]
     # SPARE was never reached, so it must not appear as an attempt.
     assert SPARE not in trail[0]
+
+
+def test_a_requested_fallback_with_nobody_to_switch_to_says_so(caplog):
+    """A flag that changes nothing must not do it silently.
+
+    The automatic ordering drops providers that invent their reports. When
+    that leaves one candidate, the run fails exactly as it would with no flag
+    at all -- and the trail is empty at position 0 either way, so nothing
+    distinguishes it from "the fallback ran and also failed". The reason is
+    the invisible part, so the run names it.
+    """
+    client = _client((PRIMARY, _params(error_type="billing")))
+    # MockProvider, not StandInProvider: it is excluded from the ordering
+    # precisely because it does not produce real reports.
+    client.registry.register(MockProvider(ProviderConfig(name=BACKUP), _params()))
+
+    # Named explicitly: at_level with no logger raises the *root* level, and a
+    # CLI test elsewhere in the suite leaves this logger pinned at WARNING, so
+    # an INFO record would be dropped before any handler saw it.
+    with caplog.at_level("INFO", logger="deep_research_client.client"):
+        with pytest.raises(ProviderBillingError):
+            client.research("q", provider=PRIMARY, fallback=True)
+
+    said = [r.getMessage() for r in caplog.records if "only candidate" in r.getMessage()]
+    assert len(said) == 1
+    assert "do not produce real reports" in said[0]
+    assert BACKUP in said[0]
+
+
+def test_a_named_fallback_that_repeats_the_primary_says_so(caplog):
+    """The other route to one candidate: the name deduplicates away."""
+    client = _client((PRIMARY, _params(error_type="billing")), (BACKUP, _params()))
+
+    # Named explicitly: at_level with no logger raises the *root* level, and a
+    # CLI test elsewhere in the suite leaves this logger pinned at WARNING, so
+    # an INFO record would be dropped before any handler saw it.
+    with caplog.at_level("INFO", logger="deep_research_client.client"):
+        with pytest.raises(ProviderBillingError):
+            client.research("q", provider=PRIMARY, fallback=[PRIMARY])
+
+    said = [r.getMessage() for r in caplog.records if "only candidate" in r.getMessage()]
+    assert len(said) == 1
+    assert "no other provider was named or available" in said[0]
+
+
+def test_a_real_fallback_does_not_claim_it_had_nobody(caplog):
+    """The diagnostic must not fire on the runs it is not about."""
+    client = _client((PRIMARY, _params(error_type="billing")), (BACKUP, _params()))
+
+    # Named explicitly: at_level with no logger raises the *root* level, and a
+    # CLI test elsewhere in the suite leaves this logger pinned at WARNING, so
+    # an INFO record would be dropped before any handler saw it.
+    with caplog.at_level("INFO", logger="deep_research_client.client"):
+        result = client.research("q", provider=PRIMARY, fallback=[BACKUP])
+
+    assert result.provider == BACKUP
+    assert not [r for r in caplog.records if "only candidate" in r.getMessage()]
+
+
+def test_the_log_says_the_run_ends_rather_than_leaving_it_open(caplog):
+    """Not misleading is not the same as informing.
+
+    Naming the candidate removed the false claim that every provider failed.
+    It did not tell an operator what became of the candidates behind it, and
+    `Providers tried:` reads as the whole list rather than a prefix of it --
+    on this path the log is the entire record, since an unclassified failure
+    carries no `provider_attempts`.
+    """
+    client = _client((PRIMARY, _params(error_type="billing")), (SPARE, _params()))
+    client.registry.register(UnclassifiableFailure(ProviderConfig(name=BACKUP), _params()))
+
+    with caplog.at_level("WARNING"):
+        with pytest.raises(RuntimeError):
+            client.research("q", provider=PRIMARY, fallback=[BACKUP, SPARE])
+
+    trail = [r.getMessage() for r in caplog.records if "Providers tried" in r.getMessage()]
+    assert len(trail) == 1
+    assert "The run ends here; any candidate after it was not tried." in trail[0]
 
 
 def test_a_lone_failure_carries_no_trail():
@@ -1140,6 +1217,35 @@ def test_cli_falls_back_when_the_named_provider_is_not_configured(tmp_path, monk
     assert "requested_provider: falcon" in content
     # The provider that could not run is in the trail, not dropped from it.
     assert "ProviderNotConfiguredError" in content
+
+
+def test_cli_prints_no_trail_header_when_there_is_no_trail(tmp_path, monkeypatch):
+    """An ordinary single-provider failure must not grow a bare header.
+
+    `ProviderError` subclasses `ValueError`, so a run with no fallback reaches
+    the same handler that prints the trail -- carrying `provider_attempts ==
+    ()`. Without the guard the handler prints "Providers tried:" with nothing
+    under it. The typo test cannot see this: that path exits from the
+    pre-check and never reaches the handler at all.
+    """
+    monkeypatch.setattr(
+        cli_module,
+        "DeepResearchClient",
+        _cli_client_with((PRIMARY, _params(error_type="billing"))),
+    )
+    output = tmp_path / "report.md"
+
+    result = CliRunner().invoke(
+        cli_module.app,
+        ["research", "q", "--provider", PRIMARY, "--output", str(output), "--no-cache"],
+    )
+
+    assert result.exit_code == 1
+    # The failure itself is reported...
+    assert "out of credits" in result.output
+    # ...but a list of one provider we already named is not a trail.
+    assert "Providers tried:" not in result.output
+    assert not output.exists()
 
 
 def test_cli_still_names_the_available_providers_for_a_typo(tmp_path, monkeypatch):

--- a/tests/test_provider_fallback.py
+++ b/tests/test_provider_fallback.py
@@ -89,6 +89,11 @@ def _restore_package_log_level():
     Containing the leak at its source beats working around it downstream,
     though it only covers tests that run after these -- see _CLIENT_LOGGER for
     the half that protects against pollution arriving from elsewhere.
+
+    The level only. _setup_logging also calls basicConfig(force=True), which
+    removes and closes every root handler, and that is deliberately out of
+    scope here: restoring closed handlers is not something a fixture can do
+    honestly. So this narrows the leak rather than closing it.
     """
     package_logger = logging.getLogger(_PACKAGE_LOGGER)
     original = package_logger.level
@@ -498,36 +503,31 @@ def test_a_named_fallback_that_repeats_the_primary_says_so(caplog):
 
     said = [r.getMessage() for r in caplog.records if "only candidate" in r.getMessage()]
     assert len(said) == 1
+    # The exact clause, to the sentence boundary: "no other provider was
+    # named" is a prefix of "...named or available", so a substring check
+    # would pass against the wrong branch. BACKUP is registered and available
+    # here -- it simply was not named -- so that branch would be false.
     assert "candidate: no other provider was named." in said[0]
-    # BACKUP is registered and available -- it just was not named. Saying
-    # "named or available" here would have been false.
-    assert "available" not in said[0]
 
 
-def test_the_automatic_route_says_available_where_the_list_route_says_named(caplog):
-    """Two situations, two sentences.
+def test_the_automatic_route_says_available(caplog):
+    """The automatic route is the one case where "available" is the truth.
 
-    On the automatic route, one candidate really does mean nothing else is
-    available. On the list route it usually means nothing else was listed --
-    and listing one is the fix. Collapsing both into "named or available"
-    asserts the first while the second is true.
+    `fallback=True` takes whatever else is registered, so one candidate really
+    does mean there is nobody else -- unlike the list route, where the usual
+    cause is that nobody else was listed. Two situations, two sentences.
     """
-    client = _client(
-        (PRIMARY, _params(error_type="billing")),
-        # A second real provider: available, and deliberately not named below.
-        (SPARE, _params()),
-    )
+    # Nobody else at all: _client passes provider_configs, so the registry
+    # holds only what is named here.
+    client = _client((PRIMARY, _params(error_type="billing")))
 
     with caplog.at_level("INFO", logger=_CLIENT_LOGGER):
         with pytest.raises(ProviderBillingError):
-            client.research("q", provider=PRIMARY, fallback=[PRIMARY])
+            client.research("q", provider=PRIMARY, fallback=True)
 
     said = [r.getMessage() for r in caplog.records if "only candidate" in r.getMessage()]
     assert len(said) == 1
-    assert "candidate: no other provider was named." in said[0]
-    # The false half: SPARE was available the whole time, so any claim about
-    # availability -- "is available", "or available" -- would be wrong here.
-    assert "available" not in said[0]
+    assert "candidate: no other provider is available." in said[0]
 
 
 def test_the_reason_given_is_the_reason_that_applied(caplog):

--- a/tests/test_provider_fallback.py
+++ b/tests/test_provider_fallback.py
@@ -429,7 +429,7 @@ def test_an_unclassified_terminal_failure_logs_the_trail_instead(caplog):
     client = _client((PRIMARY, _params(error_type="billing")))
     client.registry.register(UnclassifiableFailure(ProviderConfig(name=BACKUP), _params()))
 
-    with caplog.at_level("WARNING"):
+    with caplog.at_level("WARNING", logger=_CLIENT_LOGGER):
         with pytest.raises(RuntimeError) as caught:
             client.research("q", provider=PRIMARY, fallback=[BACKUP])
 
@@ -452,7 +452,7 @@ def test_an_unclassified_failure_before_the_last_candidate_names_itself(caplog):
     client = _client((PRIMARY, _params(error_type="billing")), (SPARE, _params()))
     client.registry.register(UnclassifiableFailure(ProviderConfig(name=BACKUP), _params()))
 
-    with caplog.at_level("WARNING"):
+    with caplog.at_level("WARNING", logger=_CLIENT_LOGGER):
         with pytest.raises(RuntimeError):
             client.research("q", provider=PRIMARY, fallback=[BACKUP, SPARE])
 
@@ -579,7 +579,7 @@ def test_the_log_says_the_run_ends_rather_than_leaving_it_open(caplog):
     client = _client((PRIMARY, _params(error_type="billing")), (SPARE, _params()))
     client.registry.register(UnclassifiableFailure(ProviderConfig(name=BACKUP), _params()))
 
-    with caplog.at_level("WARNING"):
+    with caplog.at_level("WARNING", logger=_CLIENT_LOGGER):
         with pytest.raises(RuntimeError):
             client.research("q", provider=PRIMARY, fallback=[BACKUP, SPARE])
 
@@ -647,7 +647,7 @@ def test_a_typo_in_the_fallback_list_fails_before_anything_is_called(caplog):
         (PRIMARY, _params(error_type="billing")),
         (BACKUP, _params()),
     )
-    with caplog.at_level("WARNING"):
+    with caplog.at_level("WARNING", logger=_CLIENT_LOGGER):
         with pytest.raises(ValueError, match="'mok_backup' not found"):
             client.research("q", provider=PRIMARY, fallback=["mok_backup", BACKUP])
 
@@ -800,7 +800,7 @@ def test_a_cached_report_is_served_even_from_a_provider_we_cannot_reach(tmp_path
     later = _client((BACKUP, _params()), cache_dir=tmp_path)
     assert "falcon" not in [p.name for p in later.registry.get_available_providers()]
 
-    with caplog.at_level("WARNING"):
+    with caplog.at_level("WARNING", logger=_CLIENT_LOGGER):
         result = later.research("q", provider="falcon", fallback=[BACKUP])
 
     assert result.provider == "falcon"
@@ -943,7 +943,7 @@ def test_a_fallback_is_announced_whether_or_not_the_answer_was_cached(
         (BACKUP, _params()),
         cache_dir=tmp_path,
     )
-    with caplog.at_level("WARNING"):
+    with caplog.at_level("WARNING", logger=_CLIENT_LOGGER):
         result = client.research("q", provider=PRIMARY, fallback=True)
 
     assert result.cached is warm_the_cache
@@ -959,7 +959,7 @@ def test_a_fallback_is_announced_whether_or_not_the_answer_was_cached(
 def test_no_fallback_is_announced_when_none_happened(caplog):
     """The warning must not fire on an ordinary run."""
     client = _client((PRIMARY, _params()))
-    with caplog.at_level("WARNING"):
+    with caplog.at_level("WARNING", logger=_CLIENT_LOGGER):
         client.research("q", provider=PRIMARY)
 
     assert not [
@@ -1006,7 +1006,7 @@ def test_dropping_overrides_is_said_out_loud(caplog):
         (PRIMARY, _params(error_type="billing")),
         (BACKUP, _params()),
     )
-    with caplog.at_level("WARNING"):
+    with caplog.at_level("WARNING", logger=_CLIENT_LOGGER):
         client.research(
             "q",
             provider=PRIMARY,
@@ -1029,7 +1029,7 @@ def test_the_dropped_override_warning_names_the_provider_that_got_them(caplog):
         (BACKUP, _params(error_type="auth")),
         (SPARE, _params()),
     )
-    with caplog.at_level("WARNING"):
+    with caplog.at_level("WARNING", logger=_CLIENT_LOGGER):
         client.research(
             "q",
             provider=PRIMARY,

--- a/tests/test_provider_fallback.py
+++ b/tests/test_provider_fallback.py
@@ -8,6 +8,7 @@ raises, so the client is exercised through its ordinary code path.
 """
 
 import json
+import logging
 
 import pytest
 from typer.testing import CliRunner
@@ -65,11 +66,34 @@ class UnclassifiableFailure(StandInProvider):
         raise RuntimeError("connection reset by peer")
 
 
-# Named explicitly wherever an INFO record is asserted on: caplog.at_level with
-# no logger raises the *root* level, and a CLI test elsewhere in this suite
-# leaves this one pinned at WARNING -- so an INFO record is dropped before any
-# handler sees it. The tests pass run alone and fail in the full suite.
+# The CLI's _setup_logging calls setLevel on the *package* logger, which is
+# process-global and was never restored -- so a CLI test anywhere in the suite
+# left every later test running under whatever level it chose. That is why the
+# INFO assertions here passed run alone and failed in the full suite.
+_PACKAGE_LOGGER = "deep_research_client"
+
+# Asserting on records still names the child explicitly, and the fixture below
+# does not make that unnecessary -- dropping it fails four tests. The fixture
+# stops *this* file leaking onward; it cannot undo a level another file already
+# pinned before these tests ran. caplog.at_level with no logger raises the
+# *root* level, which the package logger's level is consulted before, so an
+# INFO record is dropped on the way. Setting a non-NOTSET level on the child
+# stops the effective-level walk there instead, whatever the parent holds.
 _CLIENT_LOGGER = "deep_research_client.client"
+
+
+@pytest.fixture(autouse=True)
+def _restore_package_log_level():
+    """Stop this file's CLI tests leaving a level behind for whoever runs next.
+
+    Containing the leak at its source beats working around it downstream,
+    though it only covers tests that run after these -- see _CLIENT_LOGGER for
+    the half that protects against pollution arriving from elsewhere.
+    """
+    package_logger = logging.getLogger(_PACKAGE_LOGGER)
+    original = package_logger.level
+    yield
+    package_logger.setLevel(original)
 
 
 def _params(**kwargs) -> MockParams:
@@ -474,7 +498,36 @@ def test_a_named_fallback_that_repeats_the_primary_says_so(caplog):
 
     said = [r.getMessage() for r in caplog.records if "only candidate" in r.getMessage()]
     assert len(said) == 1
-    assert "no other provider was named or available" in said[0]
+    assert "candidate: no other provider was named." in said[0]
+    # BACKUP is registered and available -- it just was not named. Saying
+    # "named or available" here would have been false.
+    assert "available" not in said[0]
+
+
+def test_the_automatic_route_says_available_where_the_list_route_says_named(caplog):
+    """Two situations, two sentences.
+
+    On the automatic route, one candidate really does mean nothing else is
+    available. On the list route it usually means nothing else was listed --
+    and listing one is the fix. Collapsing both into "named or available"
+    asserts the first while the second is true.
+    """
+    client = _client(
+        (PRIMARY, _params(error_type="billing")),
+        # A second real provider: available, and deliberately not named below.
+        (SPARE, _params()),
+    )
+
+    with caplog.at_level("INFO", logger=_CLIENT_LOGGER):
+        with pytest.raises(ProviderBillingError):
+            client.research("q", provider=PRIMARY, fallback=[PRIMARY])
+
+    said = [r.getMessage() for r in caplog.records if "only candidate" in r.getMessage()]
+    assert len(said) == 1
+    assert "candidate: no other provider was named." in said[0]
+    # The false half: SPARE was available the whole time, so any claim about
+    # availability -- "is available", "or available" -- would be wrong here.
+    assert "available" not in said[0]
 
 
 def test_the_reason_given_is_the_reason_that_applied(caplog):
@@ -498,7 +551,7 @@ def test_the_reason_given_is_the_reason_that_applied(caplog):
 
     said = [r.getMessage() for r in caplog.records if "only candidate" in r.getMessage()]
     assert len(said) == 1
-    assert "no other provider was named or available" in said[0]
+    assert "candidate: no other provider was named." in said[0]
     assert "do not produce real reports" not in said[0]
     assert BACKUP not in said[0]
 

--- a/tests/test_provider_fallback.py
+++ b/tests/test_provider_fallback.py
@@ -66,7 +66,7 @@ class UnclassifiableFailure(StandInProvider):
         raise RuntimeError("connection reset by peer")
 
 
-# The CLI's _setup_logging calls setLevel on the *package* logger, which is
+# The CLI's setup_logging calls setLevel on the *package* logger, which is
 # process-global and was never restored -- so a CLI test anywhere in the suite
 # left every later test running under whatever level it chose. That is why the
 # INFO assertions here passed run alone and failed in the full suite.
@@ -90,15 +90,25 @@ def _restore_package_log_level():
     though it only covers tests that run after these -- see _CLIENT_LOGGER for
     the half that protects against pollution arriving from elsewhere.
 
-    The level only. _setup_logging also calls basicConfig(force=True), which
-    removes and closes every root handler, and that is deliberately out of
-    scope here: restoring closed handlers is not something a fixture can do
-    honestly. So this narrows the leak rather than closing it.
+    Two levels, because setup_logging pins two: setLevel on the package
+    logger, and basicConfig(level=..., force=True), which sets the root
+    logger's as well. Only one test here passes -v; before it existed every
+    CLI test ran at the default, so root was reassigned the value it already
+    held and the second half never showed. Demonstrated with two tests in a
+    file of their own -- in this suite the next CLI test happens to reset root
+    on its way past, which masks it rather than making it harmless.
+
+    Handlers are deliberately out of scope: basicConfig(force=True) also
+    removes and *closes* every root handler, and restoring closed handlers is
+    not something a fixture can do honestly. So this narrows the leak rather
+    than closing it.
     """
     package_logger = logging.getLogger(_PACKAGE_LOGGER)
-    original = package_logger.level
+    root_logger = logging.getLogger()
+    levels = (package_logger.level, root_logger.level)
     yield
-    package_logger.setLevel(original)
+    package_logger.setLevel(levels[0])
+    root_logger.setLevel(levels[1])
 
 
 def _params(**kwargs) -> MockParams:
@@ -1328,6 +1338,10 @@ def test_cli_v_surfaces_the_inert_fallback_diagnostic(tmp_path, monkeypatch):
     )
 
     assert result.exit_code == 1
+    # The prefix too, not just the message: the docs quote a literal console
+    # line, and the level-and-format half of it is what a reader diffs
+    # against their terminal.
+    assert "INFO - Fallback was requested" in result.output
     assert "candidate: no other provider is available." in result.output
     assert not output.exists()
 


### PR DESCRIPTION
Follow-up to #75. Four of these came out of that PR's final review pass and were deferred rather than dropped; the list is recorded in [its closing comments](https://github.com/monarch-initiative/deep-research-client/pull/75#issuecomment-5444194194).

Only the first item changes behaviour, and it only adds a log line.

## A fallback could change nothing, silently

`--fallback` can leave exactly one candidate, and the run then fails exactly as it would with no flag at all. Two routes, both easy to hit:

```
ENABLE_MOCK_PROVIDER=true          # falcon + mock configured
research "q" --provider falcon --fallback              # mock is filtered out
research "q" --provider falcon --fallback-provider falcon   # dedups away
```

The first is the automatic ordering dropping providers that do not produce real reports — correct, and the exclusion stays. But `provider_attempts` is empty at position 0 either way, so nothing distinguished *there was nobody to switch to* from *the fallback ran and also failed*. The reason was precisely the invisible part.

`_fallback_candidates` now says which, naming the excluded provider when that is the cause:

```
INFO  Fallback was requested, but falcon is the only candidate: the other
      available provider(s) do not produce real reports (mock). The run will
      behave as though no fallback was asked for
```

## The same fact, reaching the places that describe it

#75 established that a failure which is not fallback-worthy **ends the run wherever it lands** — a 429 at candidate 1 of 3 means candidates 2 and 3 are never called. The log line was fixed there. Three descriptions of the same mechanism still said the run ends when "every candidate failed", which is only the last of those cases:

- the comment on the CLI's total-failure handler,
- two sentences in `docs/how-to/choose-provider.md`,
- and, underneath all three, a gap in the failure table. It said which failures do *not* fall back; it never said they end the run rather than skipping ahead. A reader who wrote `--fallback-provider a --fallback-provider b` and got a 429 from `a` had no sentence telling them `b` was never called. That is now stated with the example that provokes it.

The log line also gains the half it was missing. Naming the candidate stopped it asserting something false about the untried ones; it still said nothing about them, and `Providers tried:` reads as the whole list rather than a prefix. On that path the log is the entire record, since an unclassified failure carries no `provider_attempts`.

## Cleanups

**`ProviderAttempt.render_trail`** replaces three copies of `"\n  ".join(attempt.summary() for attempt in ...)` across two files. The two-space indent and the `summary()` choice are what let an operator recognise the total-failure trail from the successful-fallback one met a week earlier; that is now a property of the code rather than of three edits staying in step. The note explaining why the console shows the provider's own error text and the committed report does not moves onto the helper, since it governs all three callers.

**`UnclassifiableFailure`** was defined twice verbatim, thirty lines apart. Once, at module level.

**The CLI's empty-trail guard** gets the negative assertion it lacked — `if attempts:` could be deleted with no test failing.

## One test took two attempts

The obvious home for that assertion was the existing typo test. It passed with the guard deleted: that path exits from the CLI's *pre-check* via `typer.Exit` and never reaches the `except ValueError` handler that prints the trail. A test that cannot fail is worse than no test, so it is now a single-provider failure, which does reach the handler carrying an empty trail — and does fail without the guard. I checked the same way for the other new guards.

Separately, two of the new tests passed alone and failed in the full suite: `caplog.at_level("INFO")` raises the *root* logger's level, and a CLI test elsewhere leaves `deep_research_client.client` pinned at WARNING, so the records were dropped before any handler saw them. They name the logger explicitly, with a comment saying why.

## Testing

**903 tests + 160 doctests, mypy and ruff clean, `mkdocs build --strict` clean.** Five new tests, no mocks of the code under test.

| Guard removed | Tests that fail |
|---|---|
| Say when a requested fallback had one candidate | 2 |
| The CLI's empty-trail guard | 1 |
| "The run ends here" in the client's log | 1 |

The first row's two tests cover the two routes separately, and a third asserts the diagnostic stays quiet on runs where a fallback genuinely happened — the failure mode of a message like this is firing when it should not.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CUcMgfCdBzEX4PLqFguEmE

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUcMgfCdBzEX4PLqFguEmE)_